### PR TITLE
api: introduce net.Listener and net.Conn wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,46 @@ $ go get -u github.com/pires/go-proxyproto
 
 ### Client (TODO)
 
-### Server (TODO)
+### Server
+
+```go
+package main
+
+import (
+	"log"
+	"net"
+	
+	proxyproto "github.com/pires/go-proxyproto"
+)
+
+func main() {
+	// Create a listener
+	addr := "localhost:9876"
+	list, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("couldn't listen to %q: %q\n", addr, err.Error())
+	}
+
+	// Wrap listener in a proxyproto listener
+	proxyListener := &proxyproto.Listener{Listener: list}
+	defer proxyListener.Close()
+
+	// Wait for a connection and accept it
+	conn, err := proxyListener.Accept()
+	defer conn.Close()
+
+	// Print connection details
+	if conn.LocalAddr() == nil {
+		log.Fatal("couldn't retrieve local address")
+	}
+	log.Printf("local address: %q", conn.LocalAddr().String())
+
+	if conn.RemoteAddr() == nil {
+		log.Fatal("couldn't retrieve remote address")
+	}
+	log.Printf("remote address: %q", conn.RemoteAddr().String())
+}
+```
 
 ## Documentation
 

--- a/header.go
+++ b/header.go
@@ -41,6 +41,20 @@ type Header struct {
 	DestinationPort    uint16
 }
 
+func (header *Header) RemoteAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   header.SourceAddress,
+		Port: int(header.SourcePort),
+	}
+}
+
+func (header *Header) LocalAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   header.DestinationAddress,
+		Port: int(header.DestinationPort),
+	}
+}
+
 // EqualTo returns true if headers are equivalent, false otherwise.
 // Deprecated: use EqualsTo instead. This method will eventually be removed.
 func (header *Header) EqualTo(otherHeader *Header) bool {

--- a/header.go
+++ b/header.go
@@ -41,6 +41,7 @@ type Header struct {
 	DestinationPort    uint16
 }
 
+// RemoteAddr returns the address of the remote endpoint of the connection.
 func (header *Header) RemoteAddr() net.Addr {
 	return &net.TCPAddr{
 		IP:   header.SourceAddress,
@@ -48,6 +49,7 @@ func (header *Header) RemoteAddr() net.Addr {
 	}
 }
 
+// LocalAddr returns the address of the local endpoint of the connection.
 func (header *Header) LocalAddr() net.Addr {
 	return &net.TCPAddr{
 		IP:   header.DestinationAddress,
@@ -77,7 +79,7 @@ func (header *Header) EqualsTo(otherHeader *Header) bool {
 		header.DestinationPort == otherHeader.DestinationPort
 }
 
-// WriteTo renders a proxy protocol header in a format to write over the wire.
+// WriteTo renders a proxy protocol header in a format and writes it to an io.Writer.
 func (header *Header) WriteTo(w io.Writer) (int64, error) {
 	buf, err := header.Format()
 	if err != nil {
@@ -87,7 +89,7 @@ func (header *Header) WriteTo(w io.Writer) (int64, error) {
 	return bytes.NewBuffer(buf).WriteTo(w)
 }
 
-// WriteTo renders a proxy protocol header in a format to write over the wire.
+// Format renders a proxy protocol header in a format to write over the wire.
 func (header *Header) Format() ([]byte, error) {
 	switch header.Version {
 	case 1:

--- a/header.go
+++ b/header.go
@@ -41,41 +41,6 @@ type Header struct {
 	DestinationPort    uint16
 }
 
-func NewHeaderFromConn(conn net.Conn, version byte, command ProtocolVersionAndCommand) (hdr *Header) {
-	hdr = &Header{
-		Version: version,
-		Command: command,
-	}
-
-	switch conn.RemoteAddr().(type) {
-	case *net.UnixAddr:
-		hdr.TransportProtocol = UnixStream
-	case *net.TCPAddr:
-		hdr.TransportProtocol = TCPv6
-		if conn.RemoteAddr().(*net.TCPAddr).IP.To4() != nil {
-			hdr.TransportProtocol = TCPv4
-		}
-
-		hdr.SourceAddress = conn.RemoteAddr().(*net.TCPAddr).IP
-		hdr.SourcePort = uint16(conn.RemoteAddr().(*net.TCPAddr).Port)
-		hdr.DestinationAddress = conn.LocalAddr().(*net.TCPAddr).IP
-		hdr.DestinationPort = uint16(conn.LocalAddr().(*net.TCPAddr).Port)
-	case *net.UDPAddr:
-		hdr.TransportProtocol = UDPv6
-		if conn.RemoteAddr().(*net.UDPAddr).IP.To4() != nil {
-			hdr.TransportProtocol = UDPv4
-		}
-		hdr.SourceAddress = conn.RemoteAddr().(*net.UDPAddr).IP
-		hdr.SourcePort = uint16(conn.RemoteAddr().(*net.UDPAddr).Port)
-		hdr.DestinationAddress = conn.LocalAddr().(*net.UDPAddr).IP
-		hdr.DestinationPort = uint16(conn.LocalAddr().(*net.UDPAddr).Port)
-	default:
-		hdr.TransportProtocol = UNSPEC
-	}
-
-	return hdr
-}
-
 func (header *Header) RemoteAddr() net.Addr {
 	return &net.TCPAddr{
 		IP:   header.SourceAddress,

--- a/header_test.go
+++ b/header_test.go
@@ -41,7 +41,7 @@ func TestReadTimeoutV1Invalid(t *testing.T) {
 	}
 }
 
-func TestEqualTo(t *testing.T) {
+func TestEqualsTo(t *testing.T) {
 	var headersEqual = []struct {
 		this, that *Header
 		expected   bool
@@ -108,6 +108,11 @@ func TestEqualTo(t *testing.T) {
 			t.Fatalf("expected %t, actual %t", tt.expected, actual)
 		}
 	}
+}
+
+// This is here just because of coveralls
+func TestEqualTo(t *testing.T) {
+	TestEqualsTo(t)
 }
 
 func TestLocalAddr(t *testing.T) {

--- a/protocol.go
+++ b/protocol.go
@@ -117,11 +117,7 @@ func (p *Conn) SetWriteDeadline(t time.Time) error {
 }
 
 func (p *Conn) readHeader() error {
-	hdr, err := Read(p.bufReader)
-	if err != nil {
-		return err
-	}
-	p.header = hdr
+	p.header, _ = Read(p.bufReader)
 	return nil
 
 }

--- a/protocol.go
+++ b/protocol.go
@@ -75,14 +75,19 @@ func (p *Conn) Read(b []byte) (int, error) {
 	return p.bufReader.Read(b)
 }
 
+// Write wraps original conn.Write
 func (p *Conn) Write(b []byte) (int, error) {
 	return p.conn.Write(b)
 }
 
+// Close wraps original conn.Close
 func (p *Conn) Close() error {
 	return p.conn.Close()
 }
 
+// LocalAddr returns the address of the server if the proxy
+// protocol is being used, otherwise just returns the address of
+// the socket server.
 func (p *Conn) LocalAddr() net.Addr {
 	p.once.Do(func() { p.readHeader() })
 	if p.header == nil {
@@ -104,14 +109,17 @@ func (p *Conn) RemoteAddr() net.Addr {
 	return p.header.RemoteAddr()
 }
 
+// SetDeadline wraps original conn.SetDeadline
 func (p *Conn) SetDeadline(t time.Time) error {
 	return p.conn.SetDeadline(t)
 }
 
+// SetReadDeadline wraps original conn.SetReadDeadline
 func (p *Conn) SetReadDeadline(t time.Time) error {
 	return p.conn.SetReadDeadline(t)
 }
 
+// SetWriteDeadline wraps original conn.SetWriteDeadline
 func (p *Conn) SetWriteDeadline(t time.Time) error {
 	return p.conn.SetWriteDeadline(t)
 }

--- a/protocol.go
+++ b/protocol.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Listener is used to wrap an underlying listener,
-// whose connections may be using the HAProxy Proxy Protocol (version 1).
+// whose connections may be using the HAProxy Proxy Protocol.
 // If the connection is using the protocol, the RemoteAddr() will return
 // the correct client address.
 //

--- a/protocol.go
+++ b/protocol.go
@@ -1,0 +1,127 @@
+package proxyproto
+
+import (
+	"bufio"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener is used to wrap an underlying listener,
+// whose connections may be using the HAProxy Proxy Protocol (version 1).
+// If the connection is using the protocol, the RemoteAddr() will return
+// the correct client address.
+//
+// Optionally define ProxyHeaderTimeout to set a maximum time to
+// receive the Proxy Protocol Header. Zero means no timeout.
+type Listener struct {
+	Listener           net.Listener
+	ProxyHeaderTimeout time.Duration
+}
+
+// Conn is used to wrap and underlying connection which
+// may be speaking the Proxy Protocol. If it is, the RemoteAddr() will
+// return the address of the client instead of the proxy address.
+type Conn struct {
+	bufReader          *bufio.Reader
+	conn               net.Conn
+	header             *Header
+	once               sync.Once
+	proxyHeaderTimeout time.Duration
+}
+
+// Accept waits for and returns the next connection to the listener.
+func (p *Listener) Accept() (net.Conn, error) {
+	// Get the underlying connection
+	conn, err := p.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(conn, p.ProxyHeaderTimeout), nil
+}
+
+// Close closes the underlying listener.
+func (p *Listener) Close() error {
+	return p.Listener.Close()
+}
+
+// Addr returns the underlying listener's network address.
+func (p *Listener) Addr() net.Addr {
+	return p.Listener.Addr()
+}
+
+// NewConn is used to wrap a net.Conn that may be speaking
+// the proxy protocol into a proxyproto.Conn
+func NewConn(conn net.Conn, timeout time.Duration) *Conn {
+	pConn := &Conn{
+		bufReader:          bufio.NewReader(conn),
+		conn:               conn,
+		proxyHeaderTimeout: timeout,
+	}
+	return pConn
+}
+
+// Read is check for the proxy protocol header when doing
+// the initial scan. If there is an error parsing the header,
+// it is returned and the socket is closed.
+func (p *Conn) Read(b []byte) (int, error) {
+	var err error
+	p.once.Do(func() {
+		err = p.readHeader()
+	})
+	if err != nil {
+		return 0, err
+	}
+	return p.bufReader.Read(b)
+}
+
+func (p *Conn) Write(b []byte) (int, error) {
+	return p.conn.Write(b)
+}
+
+func (p *Conn) Close() error {
+	return p.conn.Close()
+}
+
+func (p *Conn) LocalAddr() net.Addr {
+	p.once.Do(func() { p.readHeader() })
+	if p.header == nil {
+		return p.conn.LocalAddr()
+	}
+
+	return p.header.LocalAddr()
+}
+
+// RemoteAddr returns the address of the client if the proxy
+// protocol is being used, otherwise just returns the address of
+// the socket peer.
+func (p *Conn) RemoteAddr() net.Addr {
+	p.once.Do(func() { p.readHeader() })
+	if p.header == nil {
+		return p.conn.RemoteAddr()
+	}
+
+	return p.header.RemoteAddr()
+}
+
+func (p *Conn) SetDeadline(t time.Time) error {
+	return p.conn.SetDeadline(t)
+}
+
+func (p *Conn) SetReadDeadline(t time.Time) error {
+	return p.conn.SetReadDeadline(t)
+}
+
+func (p *Conn) SetWriteDeadline(t time.Time) error {
+	return p.conn.SetWriteDeadline(t)
+}
+
+func (p *Conn) readHeader() error {
+	hdr, err := Read(p.bufReader)
+	if err != nil {
+		return err
+	}
+	p.header = hdr
+	return nil
+
+}

--- a/protocol.go
+++ b/protocol.go
@@ -124,8 +124,13 @@ func (p *Conn) SetWriteDeadline(t time.Time) error {
 	return p.conn.SetWriteDeadline(t)
 }
 
-func (p *Conn) readHeader() error {
-	p.header, _ = Read(p.bufReader)
-	return nil
+func (p *Conn) readHeader() (err error) {
+	p.header, err = Read(p.bufReader)
+	// For the purpose of this wrapper shamefully stolen from armon/go-proxyproto
+	// let's act as if there was no error when PROXY protocol is not present.
+	if err == ErrNoProxyProtocol {
+		err = nil
+	}
 
+	return
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -26,18 +26,6 @@ func TestPassthrough(t *testing.T) {
 		}
 		defer conn.Close()
 
-		// Write out the header!
-		header := &Header{
-			Version:            2,
-			Command:            PROXY,
-			TransportProtocol:  TCPv4,
-			SourceAddress:      net.ParseIP("10.1.1.1"),
-			SourcePort:         1000,
-			DestinationAddress: net.ParseIP("20.2.2.2"),
-			DestinationPort:    2000,
-		}
-		header.WriteTo(conn)
-
 		conn.Write([]byte("ping"))
 		recv := make([]byte, 4)
 		_, err = conn.Read(recv)
@@ -88,18 +76,6 @@ func TestTimeout(t *testing.T) {
 
 		// Do not send data for a while
 		time.Sleep(clientWriteDelay)
-
-		// Write out the header!
-		header := &Header{
-			Version: 1,
-			//Command:            PROXY, // not needed in v1
-			TransportProtocol:  TCPv4,
-			SourceAddress:      net.ParseIP("127.0.0.1"),
-			SourcePort:         1000,
-			DestinationAddress: net.ParseIP("20.2.2.2"),
-			DestinationPort:    2000,
-		}
-		header.WriteTo(conn)
 
 		conn.Write([]byte("ping"))
 		recv := make([]byte, 4)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,0 +1,254 @@
+package proxyproto
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+const (
+	goodAddr = "127.0.0.1"
+	badAddr  = "127.0.0.2"
+	errAddr  = "9999.0.0.2"
+)
+
+var (
+	checkAddr string
+)
+
+func TestPassthrough(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	pl := &Listener{Listener: l}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := "PROXY TCP4 10.1.1.1 20.2.2.2 1000 2000\r\n"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	clientWriteDelay := 200 * time.Millisecond
+	proxyHeaderTimeout := 50 * time.Millisecond
+	pl := &Listener{Listener: l, ProxyHeaderTimeout: proxyHeaderTimeout}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Do not send data for a while
+		time.Sleep(clientWriteDelay)
+
+		// Write out the header!
+		header := "PROXY TCP4 127.0.0.1 20.2.2.2 1000 2000\r\n"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	// Check the remote addr is the original 127.0.0.1
+	remoteAddrStartTime := time.Now()
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "127.0.0.1" {
+		t.Fatalf("bad: %v", addr)
+	}
+	remoteAddrDuration := time.Since(remoteAddrStartTime)
+
+	// Check RemoteAddr() call did timeout
+	if remoteAddrDuration <= clientWriteDelay {
+		t.Fatalf("RemoteAddr() should've taken longer than the specified timeout: %v < %v", proxyHeaderTimeout, remoteAddrDuration)
+	}
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestParse_ipv4(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	pl := &Listener{Listener: l}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := "PROXY TCP4 10.1.1.1 20.2.2.2 1000 2000\r\n"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the remote addr
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "10.1.1.1" {
+		t.Fatalf("bad: %v", addr)
+	}
+	if addr.Port != 1000 {
+		t.Fatalf("bad: %v", addr)
+	}
+}
+
+func TestParse_ipv6(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	pl := &Listener{Listener: l}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := "PROXY TCP6 ffff::ffff ffff::ffff 1000 2000\r\n"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the remote addr
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "ffff::ffff" {
+		t.Fatalf("bad: %v", addr)
+	}
+	if addr.Port != 1000 {
+		t.Fatalf("bad: %v", addr)
+	}
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,3 +1,7 @@
+// This file was shamefully stolen from github.com/armon/go-proxyproto.
+// It has been heavily edited to conform to this lib.
+//
+// Thanks @armon
 package proxyproto
 
 import (
@@ -5,16 +9,6 @@ import (
 	"net"
 	"testing"
 	"time"
-)
-
-const (
-	goodAddr = "127.0.0.1"
-	badAddr  = "127.0.0.2"
-	errAddr  = "9999.0.0.2"
-)
-
-var (
-	checkAddr string
 )
 
 func TestPassthrough(t *testing.T) {
@@ -33,8 +27,16 @@ func TestPassthrough(t *testing.T) {
 		defer conn.Close()
 
 		// Write out the header!
-		header := "PROXY TCP4 10.1.1.1 20.2.2.2 1000 2000\r\n"
-		conn.Write([]byte(header))
+		header := &Header{
+			Version:            2,
+			Command:            PROXY,
+			TransportProtocol:  TCPv4,
+			SourceAddress:      net.ParseIP("10.1.1.1"),
+			SourcePort:         1000,
+			DestinationAddress: net.ParseIP("20.2.2.2"),
+			DestinationPort:    2000,
+		}
+		header.WriteTo(conn)
 
 		conn.Write([]byte("ping"))
 		recv := make([]byte, 4)
@@ -88,8 +90,16 @@ func TestTimeout(t *testing.T) {
 		time.Sleep(clientWriteDelay)
 
 		// Write out the header!
-		header := "PROXY TCP4 127.0.0.1 20.2.2.2 1000 2000\r\n"
-		conn.Write([]byte(header))
+		header := &Header{
+			Version: 1,
+			//Command:            PROXY, // not needed in v1
+			TransportProtocol:  TCPv4,
+			SourceAddress:      net.ParseIP("127.0.0.1"),
+			SourcePort:         1000,
+			DestinationAddress: net.ParseIP("20.2.2.2"),
+			DestinationPort:    2000,
+		}
+		header.WriteTo(conn)
 
 		conn.Write([]byte("ping"))
 		recv := make([]byte, 4)
@@ -151,8 +161,16 @@ func TestParse_ipv4(t *testing.T) {
 		defer conn.Close()
 
 		// Write out the header!
-		header := "PROXY TCP4 10.1.1.1 20.2.2.2 1000 2000\r\n"
-		conn.Write([]byte(header))
+		header := &Header{
+			Version:            2,
+			Command:            PROXY,
+			TransportProtocol:  TCPv4,
+			SourceAddress:      net.ParseIP("10.1.1.1"),
+			SourcePort:         1000,
+			DestinationAddress: net.ParseIP("20.2.2.2"),
+			DestinationPort:    2000,
+		}
+		header.WriteTo(conn)
 
 		conn.Write([]byte("ping"))
 		recv := make([]byte, 4)
@@ -210,8 +228,16 @@ func TestParse_ipv6(t *testing.T) {
 		defer conn.Close()
 
 		// Write out the header!
-		header := "PROXY TCP6 ffff::ffff ffff::ffff 1000 2000\r\n"
-		conn.Write([]byte(header))
+		header := &Header{
+			Version:            2,
+			Command:            PROXY,
+			TransportProtocol:  TCPv6,
+			SourceAddress:      net.ParseIP("ffff::ffff"),
+			SourcePort:         1000,
+			DestinationAddress: net.ParseIP("ffff::ffff"),
+			DestinationPort:    2000,
+		}
+		header.WriteTo(conn)
 
 		conn.Write([]byte("ping"))
 		recv := make([]byte, 4)

--- a/v1.go
+++ b/v1.go
@@ -3,7 +3,6 @@ package proxyproto
 import (
 	"bufio"
 	"bytes"
-	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -65,7 +64,7 @@ func parseVersion1(reader *bufio.Reader) (*Header, error) {
 	return header, nil
 }
 
-func (header *Header) writeVersion1(w io.Writer) (int64, error) {
+func (header *Header) formatVersion1() ([]byte, error) {
 	// As of version 1, only "TCP4" ( \x54 \x43 \x50 \x34 ) for TCP over IPv4,
 	// and "TCP6" ( \x54 \x43 \x50 \x36 ) for TCP over IPv6 are allowed.
 	proto := "UNKNOWN"
@@ -89,7 +88,7 @@ func (header *Header) writeVersion1(w io.Writer) (int64, error) {
 	buf.WriteString(strconv.Itoa(int(header.DestinationPort)))
 	buf.WriteString(CRLF)
 
-	return buf.WriteTo(w)
+	return buf.Bytes(), nil
 }
 
 func parseV1PortNumber(portStr string) (port uint16, err error) {

--- a/v2.go
+++ b/v2.go
@@ -146,7 +146,7 @@ func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
 	return header, nil
 }
 
-func (header *Header) writeVersion2(w io.Writer) (int64, error) {
+func (header *Header) formatVersion2() ([]byte, error) {
 	var buf bytes.Buffer
 	buf.Write(SIGV2)
 	buf.WriteByte(header.Command.toByte())
@@ -187,7 +187,7 @@ func (header *Header) writeVersion2(w io.Writer) (int64, error) {
 
 	}
 
-	return buf.WriteTo(w)
+	return buf.Bytes(), nil
 }
 
 func (header *Header) validateLength(length uint16) bool {


### PR DESCRIPTION
This is an attempt to partially address #3 with pieces of #2. The reason why I'm not merging #2 ~(or the code I have here)~ is because I don't feel confident enough it isn't introducing breaking changes to any existing users of this library who may be pulling from master branch.

@Freeaqingme @mgouline @elico @anisse can you PTAL?

**TODO**
- [x] fix `golint` output
- [x] add test(s) for any added functions wherever makes sense
- [ ] ~add `net.Dial` example in order to fix #2~