### PR TITLE
Add possibility to handle proxy info differently depending on upstream IP

### DIFF
--- a/header.go
+++ b/header.go
@@ -28,6 +28,7 @@ var (
 	ErrInvalidLength                        = errors.New("Invalid length")
 	ErrInvalidAddress                       = errors.New("Invalid address")
 	ErrInvalidPortNumber                    = errors.New("Invalid port number")
+	ErrSuperfluousProxyHeader               = errors.New("Upstream connection sent PROXY header but isn't allowed to send one")
 )
 
 // Header is the placeholder for proxy protocol header.

--- a/policy.go
+++ b/policy.go
@@ -1,6 +1,10 @@
 package proxyproto
 
-import "net"
+import (
+	"fmt"
+	"net"
+	"strings"
+)
 
 // PolicyFunc can be used to decide whether to trust the PROXY info from
 // upstream. If set, the connecting address is passed in as an argument.
@@ -30,34 +34,75 @@ const (
 	REQUIRE
 )
 
+// WithPolicy adds given policy to a connection when passed as option to NewConn()
+func WithPolicy(p Policy) func(*Conn) {
+	return func(c *Conn) {
+		c.ProxyHeaderPolicy = p
+	}
+}
+
 // LaxWhiteListPolicy returns a PolicyFunc which decides whether the
 // upstream ip is allowed to send a proxy header based on a list of allowed
-// IP addresses. In case upstream IP is not in list the proxy header will
-// be ignored.
-func LaxWhiteListPolicy(allowed []string) PolicyFunc {
-	return whitelistPolicy(allowed, IGNORE)
+// IP addresses and IP ranges. In case upstream IP is not in list the proxy
+// header will be ignored. If one of the provided IP addresses or IP ranges
+// is invalid it will return an error instead of a PolicyFunc.
+func LaxWhiteListPolicy(allowed []string) (PolicyFunc, error) {
+	allowFrom, err := parse(allowed)
+	if err != nil {
+		return nil, err
+	}
+
+	return whitelistPolicy(allowFrom, IGNORE), nil
+}
+
+// MustLaxWhiteListPolicy returns a LaxWhiteListPolicy but will panic if one
+// of the provided IP addresses or IP ranges is invalid.
+func MustLaxWhiteListPolicy(allowed []string) PolicyFunc {
+	pfunc, err := LaxWhiteListPolicy(allowed)
+	if err != nil {
+		panic(err)
+	}
+
+	return pfunc
 }
 
 // StrictWhiteListPolicy returns a PolicyFunc which decides whether the
 // upstream ip is allowed to send a proxy header based on a list of allowed
-// IP addresses. In case upstream IP is not in list reading on the
-// connection will be refused on the first read. Please note: subsequent
+// IP addresses and IP ranges. In case upstream IP is not in list reading on
+// the connection will be refused on the first read. Please note: subsequent
 // reads do not error. It is the task of the code using the connection to
-// handle that case properly.
-func StrictWhiteListPolicy(allowed []string) PolicyFunc {
-	return whitelistPolicy(allowed, REJECT)
+// handle that case properly. If one of the provided IP addresses or IP
+// ranges is invalid it will return an error instead of a PolicyFunc.
+func StrictWhiteListPolicy(allowed []string) (PolicyFunc, error) {
+	allowFrom, err := parse(allowed)
+	if err != nil {
+		return nil, err
+	}
+
+	return whitelistPolicy(allowFrom, REJECT), nil
 }
 
-func whitelistPolicy(allowed []string, def Policy) PolicyFunc {
+// MustStrictWhiteListPolicy returns a StrictWhiteListPolicy but will panic
+// if one of the provided IP addresses or IP ranges is invalid.
+func MustStrictWhiteListPolicy(allowed []string) PolicyFunc {
+	pfunc, err := StrictWhiteListPolicy(allowed)
+	if err != nil {
+		panic(err)
+	}
+
+	return pfunc
+}
+
+func whitelistPolicy(allowed []func(net.IP) bool, def Policy) PolicyFunc {
 	return func(upstream net.Addr) (Policy, error) {
-		upstreamIP, _, err := net.SplitHostPort(upstream.String())
+		upstreamIP, err := ipFromAddr(upstream)
 		if err != nil {
 			// something is wrong with the source IP, better reject the connection
 			return REJECT, err
 		}
 
 		for _, allowFrom := range allowed {
-			if allowFrom == upstreamIP {
+			if allowFrom(upstreamIP) {
 				return USE, nil
 			}
 		}
@@ -66,9 +111,39 @@ func whitelistPolicy(allowed []string, def Policy) PolicyFunc {
 	}
 }
 
-// WithPolicy adds given policy to a connection when passed as option to NewConn()
-func WithPolicy(p Policy) func(*Conn) {
-	return func(c *Conn) {
-		c.ProxyHeaderPolicy = p
+func parse(allowed []string) ([]func(net.IP) bool, error) {
+	a := make([]func(net.IP) bool, len(allowed))
+	for i, allowFrom := range allowed {
+		if strings.LastIndex(allowFrom, "/") > 0 {
+			_, ipRange, err := net.ParseCIDR(allowFrom)
+			if err != nil {
+				return nil, fmt.Errorf("Given string %q is not a valid IP range: %v", allowFrom, err)
+			}
+
+			a[i] = ipRange.Contains
+		} else {
+			allowed := net.ParseIP(allowFrom)
+			if allowed == nil {
+				return nil, fmt.Errorf("Given string %q is not a valid IP address", allowFrom)
+			}
+
+			a[i] = allowed.Equal
+		}
 	}
+
+	return a, nil
+}
+
+func ipFromAddr(upstream net.Addr) (net.IP, error) {
+	upstreamString, _, err := net.SplitHostPort(upstream.String())
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamIP := net.ParseIP(upstreamString)
+	if nil == upstreamIP {
+		return nil, fmt.Errorf("invalid IP address")
+	}
+
+	return upstreamIP, nil
 }

--- a/policy.go
+++ b/policy.go
@@ -1,0 +1,67 @@
+package proxyproto
+
+import "net"
+
+// PolicyFunc can be used to decide whether to trust the PROXY info from
+// upstream. If set, the connecting address is passed in as an argument.
+//
+// See below for the different policies.
+//
+// In case an error is returned the connection is denied.
+type PolicyFunc func(upstream net.Addr) (Policy, error)
+
+// Policy defines how a connection with a PROXY header address is treated.
+type Policy int
+
+const (
+	// USE address from PROXY header
+	USE Policy = iota
+	// IGNORE address from PROXY header, but accept connection
+	IGNORE
+	// REJECT connection when PROXY header is sent
+	// Note: even though the first read on the connection returns an error if
+	// a PROXY header is present, subsequent reads do not. It is the task of
+	// the code using the connection to handle that case properly.
+	REJECT
+	// REQUIRE connection to send PROXY header, reject if not present
+	// Note: even though the first read on the connection returns an error if
+	// a PROXY header is not present, subsequent reads do not. It is the task
+	// of the code using the connection to handle that case properly.
+	REQUIRE
+)
+
+// LaxWhiteListPolicy returns a PolicyFunc which decides whether the
+// upstream ip is allowed to send a proxy header based on a list of allowed
+// IP addresses. In case upstream IP is not in list the proxy header will
+// be ignored.
+func LaxWhiteListPolicy(allowed []string) PolicyFunc {
+	return whitelistPolicy(allowed, IGNORE)
+}
+
+// StrictWhiteListPolicy returns a PolicyFunc which decides whether the
+// upstream ip is allowed to send a proxy header based on a list of allowed
+// IP addresses. In case upstream IP is not in list reading on the
+// connection will be refused on the first read. Please note: subsequent
+// reads do not error. It is the task of the code using the connection to
+// handle that case properly.
+func StrictWhiteListPolicy(allowed []string) PolicyFunc {
+	return whitelistPolicy(allowed, REJECT)
+}
+
+func whitelistPolicy(allowed []string, def Policy) PolicyFunc {
+	return func(upstream net.Addr) (Policy, error) {
+		upstreamIP, _, err := net.SplitHostPort(upstream.String())
+		if err != nil {
+			// something is wrong with the source IP, better reject the connection
+			return REJECT, err
+		}
+
+		for _, allowFrom := range allowed {
+			if allowFrom == upstreamIP {
+				return USE, nil
+			}
+		}
+
+		return def, nil
+	}
+}

--- a/policy.go
+++ b/policy.go
@@ -69,6 +69,6 @@ func whitelistPolicy(allowed []string, def Policy) PolicyFunc {
 // WithPolicy adds given policy to a connection when passed as option to NewConn()
 func WithPolicy(p Policy) func(*Conn) {
 	return func(c *Conn) {
-		c.proxyHeaderPolicy = p
+		c.ProxyHeaderPolicy = p
 	}
 }

--- a/policy.go
+++ b/policy.go
@@ -65,3 +65,9 @@ func whitelistPolicy(allowed []string, def Policy) PolicyFunc {
 		return def, nil
 	}
 }
+
+func WithPolicy(p Policy) func(*Conn) {
+	return func(c *Conn) {
+		c.proxyHeaderPolicy = p
+	}
+}

--- a/policy.go
+++ b/policy.go
@@ -66,6 +66,7 @@ func whitelistPolicy(allowed []string, def Policy) PolicyFunc {
 	}
 }
 
+// WithPolicy adds given policy to a connection when passed as option to NewConn()
 func WithPolicy(p Policy) func(*Conn) {
 	return func(c *Conn) {
 		c.proxyHeaderPolicy = p

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,94 @@
+package proxyproto
+
+import (
+	"net"
+	"testing"
+)
+
+type failingAddr struct{}
+
+func (f failingAddr) Network() string { return "failing" }
+func (f failingAddr) String() string  { return "failing" }
+
+func TestWhitelistPolicyReturnsErrorOnInvalidAddress(t *testing.T) {
+	var cases = []struct {
+		name   string
+		policy PolicyFunc
+	}{
+		{"strict whitelist policy", StrictWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})},
+		{"lax whitelist policy", LaxWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.policy(failingAddr{})
+			if err == nil {
+				t.Fatal("Expected error, got none")
+			}
+		})
+	}
+}
+
+func TestStrictWhitelistPolicyReturnsRejectWhenUpstreamIpAddrNotInWhitelist(t *testing.T) {
+	p := StrictWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})
+
+	upstream, err := net.ResolveTCPAddr("tcp", "10.0.0.5:45738")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	policy, err := p(upstream)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if policy != REJECT {
+		t.Fatalf("Expected policy REJECT, got %v", policy)
+	}
+}
+
+func TestLaxWhitelistPolicyReturnsIgnoreWhenUpstreamIpAddrNotInWhitelist(t *testing.T) {
+	p := LaxWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})
+
+	upstream, err := net.ResolveTCPAddr("tcp", "10.0.0.5:45738")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	policy, err := p(upstream)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if policy != IGNORE {
+		t.Fatalf("Expected policy IGNORE, got %v", policy)
+	}
+}
+
+func TestWhitelistPolicyReturnsUseWhenUpstreamIpAddrInWhitelist(t *testing.T) {
+	var cases = []struct {
+		name   string
+		policy PolicyFunc
+	}{
+		{"strict whitelist policy", StrictWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})},
+		{"lax whitelist policy", LaxWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})},
+	}
+
+	upstream, err := net.ResolveTCPAddr("tcp", "10.0.0.3:45738")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy, err := tc.policy(upstream)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			if policy != USE {
+				t.Fatalf("Expected policy USE, got %v", policy)
+			}
+		})
+	}
+}

--- a/protocol.go
+++ b/protocol.go
@@ -45,7 +45,7 @@ func (p *Listener) Accept() (net.Conn, error) {
 		}
 	}
 
-	newConn := NewConn(conn, proxyHeaderPolicy)
+	newConn := NewConn(conn, WithPolicy(proxyHeaderPolicy))
 	return newConn, nil
 }
 
@@ -61,12 +61,16 @@ func (p *Listener) Addr() net.Addr {
 
 // NewConn is used to wrap a net.Conn that may be speaking
 // the proxy protocol into a proxyproto.Conn
-func NewConn(conn net.Conn, proxyHeaderPolicy Policy) *Conn {
+func NewConn(conn net.Conn, opts ...func(*Conn)) *Conn {
 	pConn := &Conn{
-		bufReader:         bufio.NewReader(conn),
-		conn:              conn,
-		proxyHeaderPolicy: proxyHeaderPolicy,
+		bufReader: bufio.NewReader(conn),
+		conn:      conn,
 	}
+
+	for _, opt := range opts {
+		opt(pConn)
+	}
+
 	return pConn
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -25,7 +25,7 @@ type Conn struct {
 	conn              net.Conn
 	header            *Header
 	once              sync.Once
-	proxyHeaderPolicy Policy
+	ProxyHeaderPolicy Policy
 	Validate          Validator
 	readErr           error
 }
@@ -168,7 +168,7 @@ func (p *Conn) readHeader() error {
 	// let's act as if there was no error when PROXY protocol is not present.
 	if err == ErrNoProxyProtocol {
 		// but not if it is required that the connection has one
-		if p.proxyHeaderPolicy == REQUIRE {
+		if p.ProxyHeaderPolicy == REQUIRE {
 			return err
 		}
 
@@ -177,7 +177,7 @@ func (p *Conn) readHeader() error {
 
 	// proxy protocol header was found
 	if err == nil && header != nil {
-		switch p.proxyHeaderPolicy {
+		switch p.ProxyHeaderPolicy {
 		case REJECT:
 			// this connection is not allowed to send one
 			return ErrSuperfluousProxyHeader

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -357,3 +357,31 @@ func TestIgnorePolicyIgnoresIpFromProxyHeader(t *testing.T) {
 		t.Fatalf("bad: %v", addr)
 	}
 }
+
+func Test_AllOptionsAreRecognized(t *testing.T) {
+	recognizedOpt1 := false
+	opt1 := func(c *Conn) {
+		recognizedOpt1 = true
+	}
+
+	recognizedOpt2 := false
+	opt2 := func(c *Conn) {
+		recognizedOpt2 = true
+	}
+
+	server, client := net.Pipe()
+	defer func() {
+		client.Close()
+	}()
+
+	c := NewConn(server, opt1, opt2)
+	if !recognizedOpt1 {
+		t.Error("Expected option 1 recognized")
+	}
+
+	if !recognizedOpt2 {
+		t.Error("Expected option 2 recognized")
+	}
+
+	c.Close()
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -6,6 +6,7 @@ package proxyproto
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"testing"
 )
@@ -186,6 +187,173 @@ func TestParse_ipv6(t *testing.T) {
 		t.Fatalf("bad: %v", addr)
 	}
 	if addr.Port != 1000 {
+		t.Fatalf("bad: %v", addr)
+	}
+}
+
+func TestAcceptReturnsErrorWhenPolicyFuncErrors(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	expectedErr := fmt.Errorf("failure")
+	policyFunc := func(upstream net.Addr) (Policy, error) { return USE, expectedErr }
+
+	pl := &Listener{Listener: l, Policy: policyFunc}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+	}()
+
+	conn, err := pl.Accept()
+	if err != expectedErr {
+		t.Fatalf("Expected error %v, got %v", expectedErr, err)
+	}
+
+	if conn != nil {
+		t.Fatalf("Expected no connection, got %v", conn)
+	}
+}
+
+func TestReadingIsRefusedWhenProxyHeaderRequiredButMissing(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	policyFunc := func(upstream net.Addr) (Policy, error) { return REQUIRE, nil }
+
+	pl := &Listener{Listener: l, Policy: policyFunc}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+		conn.Write([]byte("ping"))
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != ErrNoProxyProtocol {
+		t.Fatalf("Expected error %v, received %v", ErrNoProxyProtocol, err)
+	}
+}
+
+func TestReadingIsRefusedWhenProxyHeaderPresentButNotAllowed(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	policyFunc := func(upstream net.Addr) (Policy, error) { return REJECT, nil }
+
+	pl := &Listener{Listener: l, Policy: policyFunc}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+		header := &Header{
+			Version:            2,
+			Command:            PROXY,
+			TransportProtocol:  TCPv4,
+			SourceAddress:      net.ParseIP("10.1.1.1"),
+			SourcePort:         1000,
+			DestinationAddress: net.ParseIP("20.2.2.2"),
+			DestinationPort:    2000,
+		}
+		header.WriteTo(conn)
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != ErrSuperfluousProxyHeader {
+		t.Fatalf("Expected error %v, received %v", ErrSuperfluousProxyHeader, err)
+	}
+}
+func TestIgnorePolicyIgnoresIpFromProxyHeader(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	policyFunc := func(upstream net.Addr) (Policy, error) { return IGNORE, nil }
+
+	pl := &Listener{Listener: l, Policy: policyFunc}
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := &Header{
+			Version:            2,
+			Command:            PROXY,
+			TransportProtocol:  TCPv4,
+			SourceAddress:      net.ParseIP("10.1.1.1"),
+			SourcePort:         1000,
+			DestinationAddress: net.ParseIP("20.2.2.2"),
+			DestinationPort:    2000,
+		}
+		header.WriteTo(conn)
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the remote addr
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "127.0.0.1" {
 		t.Fatalf("bad: %v", addr)
 	}
 }


### PR DESCRIPTION
This introduces the possibility to decide on each new incoming connection whether the proxy header should be used, ignored, or the connection be rejected. It also allows to reject the connection when a proxy header is required but not send at all.

Without such a possibility usage of this library is prone to security attacks enabling simple faking of client IP addresses by accepting any proxy protocol header regardless of whether the upstream source is allowed to send one or not. The need for this is derived from our use case, where we have an application which accepts connections both through a proxy and direct (there's a reason for that). If we would allow the proxy header for direct connections it would allow clients to pretend they are from another IP address which we don't want.

While `NewConn` is part of the public API I decided to change it nevertheless as no official release or version of this library exists yet. In case you want to keep it as is I'd introduce another function  `NewConnWithPolicy` instead where the caller can provide the policy, and fall back to the `USE` policy in `NewConn`.