### PR TITLE
proxyv2 LOCAL commands still need to skip over dummy header fields.

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -90,7 +90,7 @@ func (p *Conn) Close() error {
 // the socket server.
 func (p *Conn) LocalAddr() net.Addr {
 	p.once.Do(func() { p.readHeader() })
-	if p.header == nil {
+	if p.header == nil || p.header.Command.IsLocal() {
 		return p.conn.LocalAddr()
 	}
 
@@ -102,7 +102,7 @@ func (p *Conn) LocalAddr() net.Addr {
 // the socket peer.
 func (p *Conn) RemoteAddr() net.Addr {
 	p.once.Do(func() { p.readHeader() })
-	if p.header == nil {
+	if p.header == nil || p.header.Command.IsLocal() {
 		return p.conn.RemoteAddr()
 	}
 

--- a/v2.go
+++ b/v2.go
@@ -72,10 +72,6 @@ func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
 	if _, ok := supportedCommand[header.Command]; !ok {
 		return nil, ErrUnsupportedProtocolVersionAndCommand
 	}
-	// If command is LOCAL, header ends here
-	if header.Command.IsLocal() {
-		return header, nil
-	}
 
 	// Read the 14th byte, address family and protocol
 	b14, err := reader.ReadByte()
@@ -150,42 +146,39 @@ func (header *Header) formatVersion2() ([]byte, error) {
 	var buf bytes.Buffer
 	buf.Write(SIGV2)
 	buf.WriteByte(header.Command.toByte())
-	if !header.Command.IsLocal() {
-		buf.WriteByte(header.TransportProtocol.toByte())
-		// TODO add encapsulated TLV length
-		var addrSrc, addrDst []byte
-		if header.TransportProtocol.IsIPv4() {
-			buf.Write(lengthV4Bytes)
-			addrSrc = header.SourceAddress.To4()
-			addrDst = header.DestinationAddress.To4()
-		} else if header.TransportProtocol.IsIPv6() {
-			buf.Write(lengthV6Bytes)
-			addrSrc = header.SourceAddress.To16()
-			addrDst = header.DestinationAddress.To16()
-		} else if header.TransportProtocol.IsUnix() {
-			buf.Write(lengthUnixBytes)
-			// TODO is below right?
-			addrSrc = []byte(header.SourceAddress.String())
-			addrDst = []byte(header.DestinationAddress.String())
-		}
-		buf.Write(addrSrc)
-		buf.Write(addrDst)
-
-		portSrcBytes := func() []byte {
-			a := make([]byte, 2)
-			binary.BigEndian.PutUint16(a, header.SourcePort)
-			return a
-		}()
-		buf.Write(portSrcBytes)
-
-		portDstBytes := func() []byte {
-			a := make([]byte, 2)
-			binary.BigEndian.PutUint16(a, header.DestinationPort)
-			return a
-		}()
-		buf.Write(portDstBytes)
-
+	buf.WriteByte(header.TransportProtocol.toByte())
+	// TODO add encapsulated TLV length
+	var addrSrc, addrDst []byte
+	if header.TransportProtocol.IsIPv4() {
+		buf.Write(lengthV4Bytes)
+		addrSrc = header.SourceAddress.To4()
+		addrDst = header.DestinationAddress.To4()
+	} else if header.TransportProtocol.IsIPv6() {
+		buf.Write(lengthV6Bytes)
+		addrSrc = header.SourceAddress.To16()
+		addrDst = header.DestinationAddress.To16()
+	} else if header.TransportProtocol.IsUnix() {
+		buf.Write(lengthUnixBytes)
+		// TODO is below right?
+		addrSrc = []byte(header.SourceAddress.String())
+		addrDst = []byte(header.DestinationAddress.String())
 	}
+	buf.Write(addrSrc)
+	buf.Write(addrDst)
+
+	portSrcBytes := func() []byte {
+		a := make([]byte, 2)
+		binary.BigEndian.PutUint16(a, header.SourcePort)
+		return a
+	}()
+	buf.Write(portSrcBytes)
+
+	portDstBytes := func() []byte {
+		a := make([]byte, 2)
+		binary.BigEndian.PutUint16(a, header.DestinationPort)
+		return a
+	}()
+	buf.Write(portDstBytes)
 
 	return buf.Bytes(), nil
 }

--- a/v2_test.go
+++ b/v2_test.go
@@ -117,10 +117,15 @@ var validParseAndWriteV2Tests = []struct {
 }{
 	// LOCAL
 	{
-		newBufioReader(append(SIGV2, LOCAL)),
+		newBufioReader(append(append(SIGV2, LOCAL, TCPv4), fixtureIPv4V2...)),
 		&Header{
-			Version: 2,
-			Command: LOCAL,
+			Version:            2,
+			Command:            LOCAL,
+			TransportProtocol:  TCPv4,
+			SourceAddress:      v4addr,
+			DestinationAddress: v4addr,
+			SourcePort:         PORT,
+			DestinationPort:    PORT,
 		},
 	},
 	// PROXY TCP IPv4


### PR DESCRIPTION
When receiving proxy v2 headers with the command field set to zero (i.e. LOCAL commands) the rest of the header should be skipped over until length.

From the spec:

> \x0 : LOCAL : the connection was established on purpose by the proxy without being relayed. The connection endpoints are the sender and the receiver. Such connections exist when the proxy sends health-checks to the server. The receiver must accept this connection as valid and must use the real connection endpoints and discard the protocol block including the family which is ignored.

and later in the spec:

> When a sender presents a LOCAL connection, it should not present any address so it sets this field to zero. Receivers MUST always consider this field to skip the appropriate number of bytes and must not assume zero is presented for LOCAL connections.

A real world example of the consequences: Amazon's Network Load Balancer (AWS NLB) sends health check packets with the LOCAL command, and uses the TCPv4 address family with dummy IP and port information. Not skipping over the header bytes following the LOCAL command up to length results in the extra header bytes passing through to the connection. In the case of HTTP health checks, this results in noise before the HTTP headers and subsequently, errors attempting to parse/server HTTP endpoints. 

Attached is an example packet capture of AWS NLB HTTP health checks (successfully parsed / responded to with this commit applied).

[AWS-NLB-HTTP-HealthCheck.zip](https://github.com/pires/go-proxyproto/files/3643425/AWS-NLB-HTTP-HealthCheck.zip)
