### PR TITLE
Use protocol header if policy is set to REQUIRE

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -181,7 +181,7 @@ func (p *Conn) readHeader() error {
 		case REJECT:
 			// this connection is not allowed to send one
 			return ErrSuperfluousProxyHeader
-		case USE:
+		case USE, REQUIRE:
 			if p.Validate != nil {
 				err = p.Validate(header)
 				if err != nil {


### PR DESCRIPTION
If the `ProxyHeaderPolicy` is set to `REQUIRE` the header is enforced but not used. This pr proposes to change this behavior to not only enforce the presence of the proxy protocol header but also using it if the policy is set to `REQUIRE`.