### PR TITLE
header: return err from reader.Peek()

### DIFF
--- a/header.go
+++ b/header.go
@@ -123,7 +123,12 @@ func (header *Header) TLVs() ([]TLV, error) {
 // Also, this operation will block until enough bytes are available for peeking.
 func Read(reader *bufio.Reader) (*Header, error) {
 	// In order to improve speed for small non-PROXYed packets, take a peek at the first byte alone.
-	if b1, err := reader.Peek(1); err == nil && (bytes.Equal(b1[:1], SIGV1[:1]) || bytes.Equal(b1[:1], SIGV2[:1])) {
+	b1, err := reader.Peek(1)
+	if err != nil {
+		return nil, err
+	}
+
+	if bytes.Equal(b1[:1], SIGV1[:1]) || bytes.Equal(b1[:1], SIGV2[:1]) {
 		if signature, err := reader.Peek(5); err == nil && bytes.Equal(signature[:5], SIGV1) {
 			return parseVersion1(reader)
 		} else if signature, err := reader.Peek(12); err == nil && bytes.Equal(signature[:12], SIGV2) {


### PR DESCRIPTION
The current behaviour of `Read` is to discard the underlying error and return `ErrNoProxyProtocol`. That makes it tricky to debug what is wrong.

In my case, I was trying to nest `tls.NewListener` inside a `proxyproto.Listener` but got the ordering wrong, the underlying error was:

```
tls: first record does not look like a TLS handshake
```

This patch surfaces that error to the caller.

Note: It may be a good idea to do the same thing with the other `.Peek()` calls too.