### PR TITLE
Prefix error messages with package name

### DIFF
--- a/header.go
+++ b/header.go
@@ -16,19 +16,19 @@ var (
 	SIGV1 = []byte{'\x50', '\x52', '\x4F', '\x58', '\x59'}
 	SIGV2 = []byte{'\x0D', '\x0A', '\x0D', '\x0A', '\x00', '\x0D', '\x0A', '\x51', '\x55', '\x49', '\x54', '\x0A'}
 
-	ErrCantReadProtocolVersionAndCommand    = errors.New("Can't read proxy protocol version and command")
-	ErrCantReadAddressFamilyAndProtocol     = errors.New("Can't read address family or protocol")
-	ErrCantReadLength                       = errors.New("Can't read length")
-	ErrCantResolveSourceUnixAddress         = errors.New("Can't resolve source Unix address")
-	ErrCantResolveDestinationUnixAddress    = errors.New("Can't resolve destination Unix address")
-	ErrNoProxyProtocol                      = errors.New("Proxy protocol signature not present")
-	ErrUnknownProxyProtocolVersion          = errors.New("Unknown proxy protocol version")
-	ErrUnsupportedProtocolVersionAndCommand = errors.New("Unsupported proxy protocol version and command")
-	ErrUnsupportedAddressFamilyAndProtocol  = errors.New("Unsupported address family and protocol")
-	ErrInvalidLength                        = errors.New("Invalid length")
-	ErrInvalidAddress                       = errors.New("Invalid address")
-	ErrInvalidPortNumber                    = errors.New("Invalid port number")
-	ErrSuperfluousProxyHeader               = errors.New("Upstream connection sent PROXY header but isn't allowed to send one")
+	ErrCantReadProtocolVersionAndCommand    = errors.New("proxyproto: can't read proxy protocol version and command")
+	ErrCantReadAddressFamilyAndProtocol     = errors.New("proxyproto: can't read address family or protocol")
+	ErrCantReadLength                       = errors.New("proxyproto: can't read length")
+	ErrCantResolveSourceUnixAddress         = errors.New("proxyproto: can't resolve source Unix address")
+	ErrCantResolveDestinationUnixAddress    = errors.New("proxyproto: can't resolve destination Unix address")
+	ErrNoProxyProtocol                      = errors.New("proxyproto: proxy protocol signature not present")
+	ErrUnknownProxyProtocolVersion          = errors.New("proxyproto: unknown proxy protocol version")
+	ErrUnsupportedProtocolVersionAndCommand = errors.New("proxyproto: unsupported proxy protocol version and command")
+	ErrUnsupportedAddressFamilyAndProtocol  = errors.New("proxyproto: unsupported address family and protocol")
+	ErrInvalidLength                        = errors.New("proxyproto: invalid length")
+	ErrInvalidAddress                       = errors.New("proxyproto: invalid address")
+	ErrInvalidPortNumber                    = errors.New("proxyproto: invalid port number")
+	ErrSuperfluousProxyHeader               = errors.New("proxyproto: upstream connection sent PROXY header but isn't allowed to send one")
 )
 
 // Header is the placeholder for proxy protocol header.

--- a/policy.go
+++ b/policy.go
@@ -117,14 +117,14 @@ func parse(allowed []string) ([]func(net.IP) bool, error) {
 		if strings.LastIndex(allowFrom, "/") > 0 {
 			_, ipRange, err := net.ParseCIDR(allowFrom)
 			if err != nil {
-				return nil, fmt.Errorf("Given string %q is not a valid IP range: %v", allowFrom, err)
+				return nil, fmt.Errorf("proxyproto: given string %q is not a valid IP range: %v", allowFrom, err)
 			}
 
 			a[i] = ipRange.Contains
 		} else {
 			allowed := net.ParseIP(allowFrom)
 			if allowed == nil {
-				return nil, fmt.Errorf("Given string %q is not a valid IP address", allowFrom)
+				return nil, fmt.Errorf("proxyproto: given string %q is not a valid IP address", allowFrom)
 			}
 
 			a[i] = allowed.Equal
@@ -142,7 +142,7 @@ func ipFromAddr(upstream net.Addr) (net.IP, error) {
 
 	upstreamIP := net.ParseIP(upstreamString)
 	if nil == upstreamIP {
-		return nil, fmt.Errorf("invalid IP address")
+		return nil, fmt.Errorf("proxyproto: invalid IP address")
 	}
 
 	return upstreamIP, nil

--- a/tlv.go
+++ b/tlv.go
@@ -32,9 +32,9 @@ const (
 )
 
 var (
-	ErrTruncatedTLV    = errors.New("Truncated TLV")
-	ErrMalformedTLV    = errors.New("Malformed TLV Value")
-	ErrIncompatibleTLV = errors.New("Incompatible TLV type")
+	ErrTruncatedTLV    = errors.New("proxyproto: truncated TLV")
+	ErrMalformedTLV    = errors.New("proxyproto: malformed TLV Value")
+	ErrIncompatibleTLV = errors.New("proxyproto: incompatible TLV type")
 )
 
 // PP2Type is the proxy protocol v2 type

--- a/v2.go
+++ b/v2.go
@@ -28,7 +28,7 @@ var (
 		binary.BigEndian.PutUint16(a, lengthUnix)
 		return a
 	}()
-	errUint16Overflow = errors.New("uint16 overflow")
+	errUint16Overflow = errors.New("proxyproto: uint16 overflow")
 )
 
 type _ports struct {


### PR DESCRIPTION
This makes it easier to track down where errors come from.