### PR TITLE
Stop exporting CRLF and SEPARATOR

### DIFF
--- a/v1.go
+++ b/v1.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	CRLF      = "\r\n"
-	SEPARATOR = " "
+	crlf      = "\r\n"
+	separator = " "
 )
 
 func initVersion1() *Header {
@@ -24,10 +24,10 @@ func initVersion1() *Header {
 func parseVersion1(reader *bufio.Reader) (*Header, error) {
 	// Make sure we have a v1 header
 	line, err := reader.ReadString('\n')
-	if !strings.HasSuffix(line, CRLF) {
+	if !strings.HasSuffix(line, crlf) {
 		return nil, ErrCantReadProtocolVersionAndCommand
 	}
-	tokens := strings.Split(line[:len(line)-2], SEPARATOR)
+	tokens := strings.Split(line[:len(line)-2], separator)
 	if len(tokens) < 6 {
 		return nil, ErrCantReadProtocolVersionAndCommand
 	}
@@ -79,17 +79,17 @@ func (header *Header) formatVersion1() ([]byte, error) {
 
 	buf := bytes.NewBuffer(make([]byte, 0, 108))
 	buf.Write(SIGV1)
-	buf.WriteString(SEPARATOR)
+	buf.WriteString(separator)
 	buf.WriteString(proto)
-	buf.WriteString(SEPARATOR)
+	buf.WriteString(separator)
 	buf.WriteString(header.SourceAddress.String())
-	buf.WriteString(SEPARATOR)
+	buf.WriteString(separator)
 	buf.WriteString(header.DestinationAddress.String())
-	buf.WriteString(SEPARATOR)
+	buf.WriteString(separator)
 	buf.WriteString(strconv.Itoa(int(header.SourcePort)))
-	buf.WriteString(SEPARATOR)
+	buf.WriteString(separator)
 	buf.WriteString(strconv.Itoa(int(header.DestinationPort)))
-	buf.WriteString(CRLF)
+	buf.WriteString(crlf)
 
 	return buf.Bytes(), nil
 }

--- a/v1_test.go
+++ b/v1_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 var (
-	TCP4AddressesAndPorts        = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, SEPARATOR)
-	TCP4AddressesAndInvalidPorts = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(INVALID_PORT), strconv.Itoa(INVALID_PORT)}, SEPARATOR)
-	TCP6AddressesAndPorts        = strings.Join([]string{IP6_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, SEPARATOR)
+	TCP4AddressesAndPorts        = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
+	TCP4AddressesAndInvalidPorts = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(INVALID_PORT), strconv.Itoa(INVALID_PORT)}, separator)
+	TCP6AddressesAndPorts        = strings.Join([]string{IP6_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
 
-	fixtureTCP4V1 = "PROXY TCP4 " + TCP4AddressesAndPorts + CRLF + "GET /"
-	fixtureTCP6V1 = "PROXY TCP6 " + TCP6AddressesAndPorts + CRLF + "GET /"
+	fixtureTCP4V1 = "PROXY TCP4 " + TCP4AddressesAndPorts + crlf + "GET /"
+	fixtureTCP6V1 = "PROXY TCP6 " + TCP6AddressesAndPorts + crlf + "GET /"
 )
 
 var invalidParseV1Tests = []struct {
@@ -38,15 +38,15 @@ var invalidParseV1Tests = []struct {
 		ErrCantReadProtocolVersionAndCommand,
 	},
 	{
-		newBufioReader([]byte("PROXY TCP6 " + TCP4AddressesAndPorts + CRLF)),
+		newBufioReader([]byte("PROXY TCP6 " + TCP4AddressesAndPorts + crlf)),
 		ErrInvalidAddress,
 	},
 	{
-		newBufioReader([]byte("PROXY TCP4 " + TCP6AddressesAndPorts + CRLF)),
+		newBufioReader([]byte("PROXY TCP4 " + TCP6AddressesAndPorts + crlf)),
 		ErrInvalidAddress,
 	},
 	// PROXY TCP IPv4
-	{newBufioReader([]byte("PROXY TCP4 " + TCP4AddressesAndInvalidPorts + CRLF)),
+	{newBufioReader([]byte("PROXY TCP4 " + TCP4AddressesAndInvalidPorts + crlf)),
 		ErrInvalidPortNumber,
 	},
 }


### PR DESCRIPTION
These are internal V1 details, users of this package shouldn't need
them.

Closes: https://github.com/pires/go-proxyproto/issues/29