### PR TITLE
Add Header.SetTLVs

### DIFF
--- a/header.go
+++ b/header.go
@@ -112,6 +112,17 @@ func (header *Header) TLVs() ([]TLV, error) {
 	return SplitTLVs(header.rawTLVs)
 }
 
+// SetTLVs sets the TLVs stored in this header. This method replaces any
+// previous TLV.
+func (header *Header) SetTLVs(tlvs []TLV) error {
+	raw, err := JoinTLVs(tlvs)
+	if err != nil {
+		return err
+	}
+	header.rawTLVs = raw
+	return nil
+}
+
 // Read identifies the proxy protocol version and reads the remaining of
 // the header, accordingly.
 //

--- a/tlv_test.go
+++ b/tlv_test.go
@@ -38,13 +38,6 @@ func checkTLVs(t *testing.T, name string, raw []byte, expected []PP2Type) []TLV 
 	return tlvs
 }
 
-func formatTLV(tlv TLV) []byte {
-	out := make([]byte, 3) // 1 = type + 2 = uint16 length
-	out[0] = byte(tlv.Type)
-	binary.BigEndian.PutUint16(out[1:3], uint16(tlv.Length))
-	return append(out, tlv.Value...)
-}
-
 var invalidTLVTests = []struct {
 	name          string
 	reader        *bufio.Reader


### PR DESCRIPTION
This is the counterpart for Header.TLVs: it populates the rawTLVs field in Header.