### PR TITLE
Update spec URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](https://godoc.org/github.com/pires/go-proxyproto?status.svg)](https://pkg.go.dev/github.com/pires/go-proxyproto?tab=doc)
 
 
-A Go library implementation of the [PROXY protocol, versions 1 and 2](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt),
+A Go library implementation of the [PROXY protocol, versions 1 and 2](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt),
 which provides, as per specification:
 > (...) a convenient way to safely transport connection
 > information such as a client's address across multiple layers of NAT or TCP

--- a/header.go
+++ b/header.go
@@ -1,5 +1,5 @@
 // Package proxyproto implements Proxy Protocol (v1 and v2) parser and writer, as per specification:
-// http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
+// https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt
 package proxyproto
 
 import (


### PR DESCRIPTION
go-proxyproto implements features that appeared in newer revisions of
the spec. Link the latest one.

While at it, convert links to HTTPS.