### PR TITLE
Don't make SSL_CN mandatory

### DIFF
--- a/tlvparse/ssl.go
+++ b/tlvparse/ssl.go
@@ -116,7 +116,6 @@ func SSL(t proxyproto.TLV) (PP2SSL, error) {
 		return PP2SSL{}, err
 	}
 	versionFound := !ssl.ClientSSL()
-	var cnFound bool
 	for _, tlv := range ssl.TLV {
 		switch tlv.Type {
 		case proxyproto.PP2_SUBTYPE_SSL_VERSION:
@@ -139,10 +138,9 @@ func SSL(t proxyproto.TLV) (PP2SSL, error) {
 			if len(tlv.Value) == 0 || !utf8.Valid(tlv.Value) {
 				return PP2SSL{}, proxyproto.ErrMalformedTLV
 			}
-			cnFound = true
 		}
 	}
-	if !(versionFound && cnFound) {
+	if !versionFound {
 		return PP2SSL{}, proxyproto.ErrMalformedTLV
 	}
 	return ssl, nil


### PR DESCRIPTION
In case the client didn't present a certificate, then there's no CN TLV that
could be populated by the proxy.

haproxy also omits this field in this case. The TLV is only appended if
ssl_sock_get_remote_common_name returns a positive integer [1]. The
function returns 0 in case the CN isn't found [2].

[1]: https://github.com/haproxy/haproxy/blob/233ad288cd4b855ba5fd08342433a0f5d20e625d/src/connection.c#L1510
[2]: https://github.com/haproxy/haproxy/blob/4299528390ce197a06c0ef1d59a4696fa9c19c30/src/ssl_sock.c#L6092