### PR TITLE
Add Generic Underlying Connection Getter

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -154,19 +154,36 @@ func (p *Conn) RemoteAddr() net.Addr {
 	return p.header.SourceAddr
 }
 
-// TCPConn returns is the underlying connection as TCPConn
+// Raw returns the underlying connection which can be casted to
+// a concrete type, allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing. 
+func (p *Conn) Raw() net.Conn {
+	return p.conn
+}
+
+// TCPConn returns the underlying TCP connection,
+// allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing. 
 func (p *Conn) TCPConn() (conn *net.TCPConn, ok bool) {
 	conn, ok = p.conn.(*net.TCPConn)
 	return
 }
 
-// UnixConn returns is the underlying connection as UnixConn
+// UnixConn returns the underlying Unix socket connection,
+// allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing. 
 func (p *Conn) UnixConn() (conn *net.UnixConn, ok bool) {
 	conn, ok = p.conn.(*net.UnixConn)
 	return
 }
 
-// UDPConn returns is the underlying connection as UDPConn
+// UDPConn returns the underlying UDP connection,
+// allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing. 
 func (p *Conn) UDPConn() (conn *net.UDPConn, ok bool) {
 	conn, ok = p.conn.(*net.UDPConn)
 	return

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -519,6 +519,10 @@ func Test_ConnectionCasts(t *testing.T) {
 	if ok {
 		t.Fatal("err: should be a tcp connection not unix")
 	}
+	_, ok = proxyprotoConn.Raw().(*net.TCPConn)
+	if !ok {
+		t.Fatal("err: should be a tcp connection")
+	}
 }
 
 func Test_ConnectionErrorsWhenHeaderValidationFails(t *testing.T) {


### PR DESCRIPTION
After the type-specific underlying connection getters were introduced in #51 There's still use for a generic getter.

For example: there might be more wrappers to the connection, and if all wrappers could implement the `Conn() net.Conn` interface, a trivial resolver could unwrap them all and get to the actual-underlying connection in a generic way.