### PR TITLE
Support v1 UNKNOWN and v2 UNSPEC when command is LOCAL

### DIFF
--- a/addr_proto.go
+++ b/addr_proto.go
@@ -13,15 +13,6 @@ const (
 	UnixDatagram AddressFamilyAndProtocol = '\x32'
 )
 
-var supportedTransportProtocol = map[AddressFamilyAndProtocol]bool{
-	TCPv4:        true,
-	UDPv4:        true,
-	TCPv6:        true,
-	UDPv6:        true,
-	UnixStream:   true,
-	UnixDatagram: true,
-}
-
 // IsIPv4 returns true if the address family is IPv4 (AF_INET4), false otherwise.
 func (ap AddressFamilyAndProtocol) IsIPv4() bool {
 	return 0x10 == ap&0xF0

--- a/header.go
+++ b/header.go
@@ -16,6 +16,7 @@ var (
 	SIGV1 = []byte{'\x50', '\x52', '\x4F', '\x58', '\x59'}
 	SIGV2 = []byte{'\x0D', '\x0A', '\x0D', '\x0A', '\x00', '\x0D', '\x0A', '\x51', '\x55', '\x49', '\x54', '\x0A'}
 
+	ErrLineMustEndWithCrlf                  = errors.New("proxyproto: header is invalid, must end with \\r\\n")
 	ErrCantReadProtocolVersionAndCommand    = errors.New("proxyproto: can't read proxy protocol version and command")
 	ErrCantReadAddressFamilyAndProtocol     = errors.New("proxyproto: can't read address family or protocol")
 	ErrCantReadLength                       = errors.New("proxyproto: can't read length")

--- a/protocol.go
+++ b/protocol.go
@@ -157,7 +157,7 @@ func (p *Conn) RemoteAddr() net.Addr {
 // Raw returns the underlying connection which can be casted to
 // a concrete type, allowing access to specialized functions.
 //
-// Use this ONLY if you know exactly what you are doing. 
+// Use this ONLY if you know exactly what you are doing.
 func (p *Conn) Raw() net.Conn {
 	return p.conn
 }
@@ -165,7 +165,7 @@ func (p *Conn) Raw() net.Conn {
 // TCPConn returns the underlying TCP connection,
 // allowing access to specialized functions.
 //
-// Use this ONLY if you know exactly what you are doing. 
+// Use this ONLY if you know exactly what you are doing.
 func (p *Conn) TCPConn() (conn *net.TCPConn, ok bool) {
 	conn, ok = p.conn.(*net.TCPConn)
 	return
@@ -174,7 +174,7 @@ func (p *Conn) TCPConn() (conn *net.TCPConn, ok bool) {
 // UnixConn returns the underlying Unix socket connection,
 // allowing access to specialized functions.
 //
-// Use this ONLY if you know exactly what you are doing. 
+// Use this ONLY if you know exactly what you are doing.
 func (p *Conn) UnixConn() (conn *net.UnixConn, ok bool) {
 	conn, ok = p.conn.(*net.UnixConn)
 	return
@@ -183,7 +183,7 @@ func (p *Conn) UnixConn() (conn *net.UnixConn, ok bool) {
 // UDPConn returns the underlying UDP connection,
 // allowing access to specialized functions.
 //
-// Use this ONLY if you know exactly what you are doing. 
+// Use this ONLY if you know exactly what you are doing.
 func (p *Conn) UDPConn() (conn *net.UDPConn, ok bool) {
 	conn, ok = p.conn.(*net.UDPConn)
 	return

--- a/v1.go
+++ b/v1.go
@@ -22,7 +22,7 @@ func initVersion1() *Header {
 }
 
 func parseVersion1(reader *bufio.Reader) (*Header, error) {
-	// Read until LR shows up, otherwise fail.
+	// Read until LF shows up, otherwise fail.
 	// At this point, can't be sure CR precedes LF which will be validated next.
 	line, err := reader.ReadString('\n')
 	if err != nil {

--- a/v1.go
+++ b/v1.go
@@ -41,13 +41,13 @@ func parseVersion1(reader *bufio.Reader) (*Header, error) {
 			transportProtocol = TCPv4
 		case "TCP6":
 			transportProtocol = TCPv6
-		case "UNKNOWN": // no-op
+		case "UNKNOWN": // no-op as UNSPEC is set already
 		default:
 			return nil, ErrCantReadAddressFamilyAndProtocol
 		}
 
 		// Expect 6 tokens only when UNKNOWN is not present.
-		if tokens[1] != "UNKNOWN" && len(tokens) < 6 {
+		if !transportProtocol.IsUnspec() && len(tokens) < 6 {
 			return nil, ErrCantReadAddressFamilyAndProtocol
 		}
 	}

--- a/v1_test.go
+++ b/v1_test.go
@@ -9,63 +9,88 @@ import (
 )
 
 var (
-	TCP4AddressesAndPorts        = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
-	TCP4AddressesAndInvalidPorts = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(INVALID_PORT), strconv.Itoa(INVALID_PORT)}, separator)
-	TCP6AddressesAndPorts        = strings.Join([]string{IP6_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
+	IPv4AddressesAndPorts        = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
+	IPv4AddressesAndInvalidPorts = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(INVALID_PORT), strconv.Itoa(INVALID_PORT)}, separator)
+	IPv6AddressesAndPorts        = strings.Join([]string{IP6_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
 
-	fixtureTCP4V1 = "PROXY TCP4 " + TCP4AddressesAndPorts + crlf + "GET /"
-	fixtureTCP6V1 = "PROXY TCP6 " + TCP6AddressesAndPorts + crlf + "GET /"
+	fixtureTCP4V1 = "PROXY TCP4 " + IPv4AddressesAndPorts + crlf + "GET /"
+	fixtureTCP6V1 = "PROXY TCP6 " + IPv6AddressesAndPorts + crlf + "GET /"
+
+	fixtureUnknown              = "PROXY UNKNOWN" + crlf
+	fixtureUnknownWithAddresses = "PROXY UNKNOWN " + IPv4AddressesAndInvalidPorts + crlf
 )
 
 var invalidParseV1Tests = []struct {
+	desc          string
 	reader        *bufio.Reader
 	expectedError error
 }{
 	{
-		newBufioReader([]byte("PROX")),
-		ErrNoProxyProtocol,
+		desc:          "no signature",
+		reader:        newBufioReader([]byte(NO_PROTOCOL)),
+		expectedError: ErrNoProxyProtocol,
 	},
 	{
-		newBufioReader([]byte(NO_PROTOCOL)),
-		ErrNoProxyProtocol,
+		desc:          "prox",
+		reader:        newBufioReader([]byte("PROX")),
+		expectedError: ErrNoProxyProtocol,
 	},
 	{
-		newBufioReader([]byte("PROXY \r\n")),
-		ErrCantReadProtocolVersionAndCommand,
+		desc:          "proxy lf",
+		reader:        newBufioReader([]byte("PROXY \n")),
+		expectedError: ErrLineMustEndWithCrlf,
 	},
 	{
-		newBufioReader([]byte("PROXY TCP4 " + TCP4AddressesAndPorts)),
-		ErrCantReadProtocolVersionAndCommand,
+		desc:          "proxy crlf",
+		reader:        newBufioReader([]byte("PROXY " + crlf)),
+		expectedError: ErrCantReadAddressFamilyAndProtocol,
 	},
 	{
-		newBufioReader([]byte("PROXY TCP6 " + TCP4AddressesAndPorts + crlf)),
-		ErrInvalidAddress,
+		desc:          "proxy something crlf",
+		reader:        newBufioReader([]byte("PROXY SOMETHING" + crlf)),
+		expectedError: ErrCantReadAddressFamilyAndProtocol,
 	},
 	{
-		newBufioReader([]byte("PROXY TCP4 " + TCP6AddressesAndPorts + crlf)),
-		ErrInvalidAddress,
+		desc:          "incomplete signature TCP4",
+		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv4AddressesAndPorts)),
+		expectedError: ErrLineMustEndWithCrlf,
 	},
-	// PROXY TCP IPv4
-	{newBufioReader([]byte("PROXY TCP4 " + TCP4AddressesAndInvalidPorts + crlf)),
-		ErrInvalidPortNumber,
+	{
+		desc:          "TCP6 with IPv4 addresses",
+		reader:        newBufioReader([]byte("PROXY TCP6 " + IPv4AddressesAndPorts + crlf)),
+		expectedError: ErrInvalidAddress,
+	},
+	{
+		desc:          "TCP4 with IPv6 addresses",
+		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv6AddressesAndPorts + crlf)),
+		expectedError: ErrInvalidAddress,
+	},
+	{
+		desc:          "TCP4 with invalid port",
+		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv4AddressesAndInvalidPorts + crlf)),
+		expectedError: ErrInvalidPortNumber,
 	},
 }
 
 func TestReadV1Invalid(t *testing.T) {
 	for _, tt := range invalidParseV1Tests {
-		if _, err := Read(tt.reader); err != tt.expectedError {
-			t.Fatalf("TestReadV1Invalid: expected %s, actual %s", tt.expectedError, err.Error())
-		}
+		t.Run(tt.desc, func(t *testing.T) {
+			if _, err := Read(tt.reader); err != tt.expectedError {
+				t.Fatalf("TestReadV1Invalid: expected %s, actual %s", tt.expectedError, err.Error())
+			}
+		})
 	}
 }
 
 var validParseAndWriteV1Tests = []struct {
+	desc           string
 	reader         *bufio.Reader
 	expectedHeader *Header
 }{
 	{
-		bufio.NewReader(strings.NewReader(fixtureTCP4V1)),
-		&Header{
+		desc:   "TCP4",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP4V1)),
+		expectedHeader: &Header{
 			Version:           1,
 			Command:           PROXY,
 			TransportProtocol: TCPv4,
@@ -74,8 +99,9 @@ var validParseAndWriteV1Tests = []struct {
 		},
 	},
 	{
-		bufio.NewReader(strings.NewReader(fixtureTCP6V1)),
-		&Header{
+		desc:   "TCP6",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP6V1)),
+		expectedHeader: &Header{
 			Version:           1,
 			Command:           PROXY,
 			TransportProtocol: TCPv6,
@@ -83,38 +109,64 @@ var validParseAndWriteV1Tests = []struct {
 			DestinationAddr:   v6addr,
 		},
 	},
+	{
+		desc:   "unknown",
+		reader: bufio.NewReader(strings.NewReader(fixtureUnknown)),
+		expectedHeader: &Header{
+			Version:           1,
+			Command:           PROXY,
+			TransportProtocol: UNSPEC,
+			SourceAddr:        nil,
+			DestinationAddr:   nil,
+		},
+	},
+	{
+		desc:   "unknown with addresses and ports",
+		reader: bufio.NewReader(strings.NewReader(fixtureUnknownWithAddresses)),
+		expectedHeader: &Header{
+			Version:           1,
+			Command:           PROXY,
+			TransportProtocol: UNSPEC,
+			SourceAddr:        nil,
+			DestinationAddr:   nil,
+		},
+	},
 }
 
 func TestParseV1Valid(t *testing.T) {
 	for _, tt := range validParseAndWriteV1Tests {
-		header, err := Read(tt.reader)
-		if err != nil {
-			t.Fatal("TestParseV1Valid: unexpected error", err.Error())
-		}
-		if !header.EqualsTo(tt.expectedHeader) {
-			t.Fatalf("TestParseV1Valid: expected %#v, actual %#v", tt.expectedHeader, header)
-		}
+		t.Run(tt.desc, func(t *testing.T) {
+			header, err := Read(tt.reader)
+			if err != nil {
+				t.Fatal("TestParseV1Valid: unexpected error", err.Error())
+			}
+			if !header.EqualsTo(tt.expectedHeader) {
+				t.Fatalf("TestParseV1Valid: expected %#v, actual %#v", tt.expectedHeader, header)
+			}
+		})
 	}
 }
 
 func TestWriteV1Valid(t *testing.T) {
 	for _, tt := range validParseAndWriteV1Tests {
-		var b bytes.Buffer
-		w := bufio.NewWriter(&b)
-		if _, err := tt.expectedHeader.WriteTo(w); err != nil {
-			t.Fatal("TestWriteV1Valid: Unexpected error ", err)
-		}
-		w.Flush()
+		t.Run(tt.desc, func(t *testing.T) {
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
+			if _, err := tt.expectedHeader.WriteTo(w); err != nil {
+				t.Fatal("TestWriteV1Valid: Unexpected error ", err)
+			}
+			w.Flush()
 
-		// Read written bytes to validate written header
-		r := bufio.NewReader(&b)
-		newHeader, err := Read(r)
-		if err != nil {
-			t.Fatal("TestWriteV1Valid: Unexpected error ", err)
-		}
+			// Read written bytes to validate written header
+			r := bufio.NewReader(&b)
+			newHeader, err := Read(r)
+			if err != nil {
+				t.Fatal("TestWriteV1Valid: Unexpected error ", err)
+			}
 
-		if !newHeader.EqualsTo(tt.expectedHeader) {
-			t.Fatalf("TestWriteV1Valid: expected %#v, actual %#v", tt.expectedHeader, newHeader)
-		}
+			if !newHeader.EqualsTo(tt.expectedHeader) {
+				t.Fatalf("TestWriteV1Valid: expected %#v, actual %#v", tt.expectedHeader, newHeader)
+			}
+		})
 	}
 }

--- a/v1_test.go
+++ b/v1_test.go
@@ -76,7 +76,7 @@ func TestReadV1Invalid(t *testing.T) {
 	for _, tt := range invalidParseV1Tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if _, err := Read(tt.reader); err != tt.expectedError {
-				t.Fatalf("TestReadV1Invalid: expected %s, actual %s", tt.expectedError, err.Error())
+				t.Fatalf("expected %s, actual %s", tt.expectedError, err.Error())
 			}
 		})
 	}
@@ -138,10 +138,10 @@ func TestParseV1Valid(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			header, err := Read(tt.reader)
 			if err != nil {
-				t.Fatal("TestParseV1Valid: unexpected error", err.Error())
+				t.Fatal("unexpected error", err.Error())
 			}
 			if !header.EqualsTo(tt.expectedHeader) {
-				t.Fatalf("TestParseV1Valid: expected %#v, actual %#v", tt.expectedHeader, header)
+				t.Fatalf("expected %#v, actual %#v", tt.expectedHeader, header)
 			}
 		})
 	}
@@ -153,7 +153,7 @@ func TestWriteV1Valid(t *testing.T) {
 			var b bytes.Buffer
 			w := bufio.NewWriter(&b)
 			if _, err := tt.expectedHeader.WriteTo(w); err != nil {
-				t.Fatal("TestWriteV1Valid: Unexpected error ", err)
+				t.Fatal("unexpected error ", err)
 			}
 			w.Flush()
 
@@ -161,11 +161,11 @@ func TestWriteV1Valid(t *testing.T) {
 			r := bufio.NewReader(&b)
 			newHeader, err := Read(r)
 			if err != nil {
-				t.Fatal("TestWriteV1Valid: Unexpected error ", err)
+				t.Fatal("unexpected error ", err)
 			}
 
 			if !newHeader.EqualsTo(tt.expectedHeader) {
-				t.Fatalf("TestWriteV1Valid: expected %#v, actual %#v", tt.expectedHeader, newHeader)
+				t.Fatalf("expected %#v, actual %#v", tt.expectedHeader, newHeader)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #60

I took the opportunity to improve test debuggability for v1 and v2 code.

Warning: changes to v1 errror handling may break someone's code but should be trivial to address. I'm taking this breaking change lightly because of that and because this is still a 0.x release, which should clearly communicate the API is not stable.