### PR TITLE
v1: fix command always LOCAL

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -537,7 +537,7 @@ func TestFormatInvalid(t *testing.T) {
 func TestHeaderProxyFromAddrs(t *testing.T) {
 	unspec := &Header{
 		Version:           2,
-		Command:           PROXY,
+		Command:           LOCAL,
 		TransportProtocol: UNSPEC,
 	}
 

--- a/v1_test.go
+++ b/v1_test.go
@@ -46,6 +46,11 @@ var invalidParseV1Tests = []struct {
 		expectedError: ErrCantReadAddressFamilyAndProtocol,
 	},
 	{
+		desc:          "proxy no space crlf",
+		reader:        newBufioReader([]byte("PROXY" + crlf)),
+		expectedError: ErrCantReadAddressFamilyAndProtocol,
+	},
+	{
 		desc:          "proxy something crlf",
 		reader:        newBufioReader([]byte("PROXY SOMETHING" + crlf)),
 		expectedError: ErrCantReadAddressFamilyAndProtocol,
@@ -114,7 +119,7 @@ var validParseAndWriteV1Tests = []struct {
 		reader: bufio.NewReader(strings.NewReader(fixtureUnknown)),
 		expectedHeader: &Header{
 			Version:           1,
-			Command:           PROXY,
+			Command:           LOCAL,
 			TransportProtocol: UNSPEC,
 			SourceAddr:        nil,
 			DestinationAddr:   nil,
@@ -125,7 +130,7 @@ var validParseAndWriteV1Tests = []struct {
 		reader: bufio.NewReader(strings.NewReader(fixtureUnknownWithAddresses)),
 		expectedHeader: &Header{
 			Version:           1,
-			Command:           PROXY,
+			Command:           LOCAL,
 			TransportProtocol: UNSPEC,
 			SourceAddr:        nil,
 			DestinationAddr:   nil,

--- a/v2.go
+++ b/v2.go
@@ -205,7 +205,6 @@ func (header *Header) formatVersion2() ([]byte, error) {
 			addrDst = formatUnixName(destAddr.Name)
 		}
 
-		//
 		if addrSrc == nil || addrDst == nil {
 			return nil, ErrInvalidAddress
 		}

--- a/version_cmd.go
+++ b/version_cmd.go
@@ -1,10 +1,16 @@
 package proxyproto
 
-// ProtocolVersionAndCommand represents proxy protocol version and command.
+// ProtocolVersionAndCommand represents the command in proxy protocol v2.
+// Command doesn't exist in v1 but it should be set since other parts of
+// this library may rely on it for determining connection details.
 type ProtocolVersionAndCommand byte
 
 const (
+	// LOCAL represents the LOCAL command in v2 or UNKNOWN transport in v1,
+	// in which case no address information is expected.
 	LOCAL ProtocolVersionAndCommand = '\x20'
+	// PROXY represents the PROXY command in v2 or transport is not UNKNOWN in v1,
+	// in which case valid local/remote address and port information is expected.
 	PROXY ProtocolVersionAndCommand = '\x21'
 )
 
@@ -13,17 +19,19 @@ var supportedCommand = map[ProtocolVersionAndCommand]bool{
 	PROXY: true,
 }
 
-// IsLocal returns true if the protocol version is \x2 and command is LOCAL, false otherwise.
+// IsLocal returns true if the command in v2 is LOCAL or the transport in v1 is UNKNOWN,
+// i.e. when no address information is expected, false otherwise.
 func (pvc ProtocolVersionAndCommand) IsLocal() bool {
-	return 0x20 == pvc&0xF0 && 0x00 == pvc&0x0F
+	return LOCAL == pvc
 }
 
-// IsProxy returns true if the protocol version is \x2 and command is PROXY, false otherwise.
+// IsProxy returns true if the command in v2 is PROXY or the transport in v1 is not UNKNOWN,
+// i.e. when valid local/remote address and port information is expected, false otherwise.
 func (pvc ProtocolVersionAndCommand) IsProxy() bool {
-	return 0x20 == pvc&0xF0 && 0x01 == pvc&0x0F
+	return PROXY == pvc
 }
 
-// IsUnspec returns true if the protocol version or command is unspecified, false otherwise.
+// IsUnspec returns true if the command is unspecified, false otherwise.
 func (pvc ProtocolVersionAndCommand) IsUnspec() bool {
 	return !(pvc.IsLocal() || pvc.IsProxy())
 }


### PR DESCRIPTION
The changes in #61 overrides all `header.Command` to `LOCAL` (which was set to `PROXY` by `initVersion1`) unconditionally.

https://github.com/pires/go-proxyproto/blob/b6f440c01c68bf65792f463adcc71eb620fb0484/v1.go#L55-L60

This makes these functions returning the original addresses rather than the addresses contained in the proxy header.

https://github.com/pires/go-proxyproto/blob/b6f440c01c68bf65792f463adcc71eb620fb0484/protocol.go#L127-L155

Unfortunately, the problem was not revealed, since the `EqualsTo` function, which is used by the tests to compare actual and expected headers, straightly returns true when the command is LOCAL, and the command is not being compared.

https://github.com/pires/go-proxyproto/blob/b6f440c01c68bf65792f463adcc71eb620fb0484/header.go#L150-L170

This PR also updated the condition that checks the token length, made it to make sense.

The comments for ProtocolVersionAndCommand are also updated, made it less confusing.