### PR TITLE
tests and fixes for issue #69

### DIFF
--- a/header.go
+++ b/header.go
@@ -16,7 +16,8 @@ var (
 	SIGV1 = []byte{'\x50', '\x52', '\x4F', '\x58', '\x59'}
 	SIGV2 = []byte{'\x0D', '\x0A', '\x0D', '\x0A', '\x00', '\x0D', '\x0A', '\x51', '\x55', '\x49', '\x54', '\x0A'}
 
-	ErrLineMustEndWithCrlf                  = errors.New("proxyproto: header is invalid, must end with \\r\\n")
+	ErrVersion1HeaderTooLong                = errors.New("proxyproto: version 1 header must be 107 bytes or less")
+	ErrLineMustEndWithCrlf                  = errors.New("proxyproto: version 1 header is invalid, must end with \\r\\n")
 	ErrCantReadProtocolVersionAndCommand    = errors.New("proxyproto: can't read proxy protocol version and command")
 	ErrCantReadAddressFamilyAndProtocol     = errors.New("proxyproto: can't read address family or protocol")
 	ErrCantReadLength                       = errors.New("proxyproto: can't read length")

--- a/header.go
+++ b/header.go
@@ -16,6 +16,7 @@ var (
 	SIGV1 = []byte{'\x50', '\x52', '\x4F', '\x58', '\x59'}
 	SIGV2 = []byte{'\x0D', '\x0A', '\x0D', '\x0A', '\x00', '\x0D', '\x0A', '\x51', '\x55', '\x49', '\x54', '\x0A'}
 
+	ErrCantReadVersion1Header               = errors.New("proxyproto: can't read version 1 header")
 	ErrVersion1HeaderTooLong                = errors.New("proxyproto: version 1 header must be 107 bytes or less")
 	ErrLineMustEndWithCrlf                  = errors.New("proxyproto: version 1 header is invalid, must end with \\r\\n")
 	ErrCantReadProtocolVersionAndCommand    = errors.New("proxyproto: can't read proxy protocol version and command")

--- a/header_test.go
+++ b/header_test.go
@@ -13,11 +13,12 @@ import (
 // Stuff to be used in both versions tests.
 
 const (
-	NO_PROTOCOL  = "There is no spoon"
-	IP4_ADDR     = "127.0.0.1"
-	IP6_ADDR     = "::1"
-	PORT         = 65533
-	INVALID_PORT = 99999
+	NO_PROTOCOL   = "There is no spoon"
+	IP4_ADDR      = "127.0.0.1"
+	IP6_ADDR      = "::1"
+	IP6_LONG_ADDR = "1234:5678:9abc:def0:cafe:babe:dead:2bad"
+	PORT          = 65533
+	INVALID_PORT  = 99999
 )
 
 var (

--- a/v1_test.go
+++ b/v1_test.go
@@ -64,7 +64,7 @@ var invalidParseV1Tests = []struct {
 	{
 		desc:          "incomplete signature TCP4",
 		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv4AddressesAndPorts)),
-		expectedError: ErrLineMustEndWithCrlf,
+		expectedError: ErrCantReadVersion1Header,
 	},
 	{
 		desc:          "TCP6 with IPv4 addresses",

--- a/v1_test.go
+++ b/v1_test.go
@@ -3,18 +3,24 @@ package proxyproto
 import (
 	"bufio"
 	"bytes"
+	"io"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (
 	IPv4AddressesAndPorts        = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
 	IPv4AddressesAndInvalidPorts = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(INVALID_PORT), strconv.Itoa(INVALID_PORT)}, separator)
 	IPv6AddressesAndPorts        = strings.Join([]string{IP6_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
+	IPv6LongAddressesAndPorts    = strings.Join([]string{IP6_LONG_ADDR, IP6_LONG_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
 
 	fixtureTCP4V1 = "PROXY TCP4 " + IPv4AddressesAndPorts + crlf + "GET /"
 	fixtureTCP6V1 = "PROXY TCP6 " + IPv6AddressesAndPorts + crlf + "GET /"
+
+	fixtureTCP6V1Overflow = "PROXY TCP6 " + IPv6LongAddressesAndPorts
 
 	fixtureUnknown              = "PROXY UNKNOWN" + crlf
 	fixtureUnknownWithAddresses = "PROXY UNKNOWN " + IPv4AddressesAndInvalidPorts + crlf
@@ -75,13 +81,18 @@ var invalidParseV1Tests = []struct {
 		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv4AddressesAndInvalidPorts + crlf)),
 		expectedError: ErrInvalidPortNumber,
 	},
+	{
+		desc:          "header too long",
+		reader:        newBufioReader([]byte("PROXY UNKNOWN " + IPv6LongAddressesAndPorts + " " + crlf)),
+		expectedError: ErrVersion1HeaderTooLong,
+	},
 }
 
 func TestReadV1Invalid(t *testing.T) {
 	for _, tt := range invalidParseV1Tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if _, err := Read(tt.reader); err != tt.expectedError {
-				t.Fatalf("expected %s, actual %s", tt.expectedError, err.Error())
+				t.Fatalf("expected %s, actual %v", tt.expectedError, err)
 			}
 		})
 	}
@@ -173,5 +184,152 @@ func TestWriteV1Valid(t *testing.T) {
 				t.Fatalf("expected %#v, actual %#v", tt.expectedHeader, newHeader)
 			}
 		})
+	}
+}
+
+// Tests for parseVersion1 overflow - issue #69.
+
+type dataSource struct {
+	NBytes int
+	NRead  int
+}
+
+func (ds *dataSource) Read(b []byte) (int, error) {
+	if ds.NRead >= ds.NBytes {
+		return 0, io.EOF
+	}
+	avail := ds.NBytes - ds.NRead
+	if len(b) < avail {
+		avail = len(b)
+	}
+	for i := 0; i < avail; i++ {
+		b[i] = 0x20
+	}
+	ds.NRead += avail
+	return avail, nil
+}
+
+func TestParseVersion1Overflow(t *testing.T) {
+	ds := &dataSource{}
+	reader := bufio.NewReader(ds)
+	bufSize := reader.Size()
+	ds.NBytes = bufSize * 16
+	parseVersion1(reader)
+	if ds.NRead > bufSize {
+		t.Fatalf("read: expected max %d bytes, actual %d\n", bufSize, ds.NRead)
+	}
+}
+
+func listen(t *testing.T) *Listener {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return &Listener{Listener: l}
+}
+
+func client(t *testing.T, addr, header string, length int, terminate bool, wait time.Duration, done chan struct{}) {
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	if terminate && length < 2 {
+		length = 2
+	}
+
+	buf := make([]byte, len(header)+length)
+	copy(buf, []byte(header))
+	for i := 0; i < length-2; i++ {
+		buf[i+len(header)] = 0x20
+	}
+	if terminate {
+		copy(buf[len(header)+length-2:], []byte(crlf))
+	}
+
+	n, err := c.Write(buf)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(buf) {
+		t.Fatalf("write; short write")
+	}
+
+	time.Sleep(wait)
+	close(done)
+}
+
+func TestVersion1Overflow(t *testing.T) {
+	done := make(chan struct{})
+
+	l := listen(t)
+	go client(t, l.Addr().String(), fixtureTCP6V1Overflow, 10240, true, 10*time.Second, done)
+
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+
+	b := []byte{}
+	_, err = c.Read(b)
+	if err == nil {
+		t.Fatalf("net.Conn: no error reported for oversized header")
+	}
+}
+
+func TestVersion1SlowLoris(t *testing.T) {
+	done := make(chan struct{})
+	timeout := make(chan error)
+
+	l := listen(t)
+	go client(t, l.Addr().String(), fixtureTCP6V1Overflow, 0, false, 10*time.Second, done)
+
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+
+	go func() {
+		b := []byte{}
+		_, err = c.Read(b)
+		timeout <- err
+	}()
+
+	select {
+	case <-done:
+		t.Fatalf("net.Conn: reader still blocked after 10 seconds")
+	case err := <-timeout:
+		if err == nil {
+			t.Fatalf("net.Conn: no error reported for incomplete header")
+		}
+	}
+}
+
+func TestVersion1SlowLorisOverflow(t *testing.T) {
+	done := make(chan struct{})
+	timeout := make(chan error)
+
+	l := listen(t)
+	go client(t, l.Addr().String(), fixtureTCP6V1Overflow, 10240, false, 10*time.Second, done)
+
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+
+	go func() {
+		b := []byte{}
+		_, err = c.Read(b)
+		timeout <- err
+	}()
+
+	select {
+	case <-done:
+		t.Fatalf("net.Conn: reader still blocked after 10 seconds")
+	case err := <-timeout:
+		if err == nil {
+			t.Fatalf("net.Conn: no error reported for incomplete and overflowed header")
+		}
 	}
 }


### PR DESCRIPTION
2As suggested in PR#70, a new pull request which captures just the tests proving issue #69, with some refinements:

- header overflow (i.e. reads more than the bufio.Reader default buffer size of 4096).
- "slow loris" type vulnerability, where the header read blocks waiting for terminator.

The second issue above can be used for DoS by consuming server process sockets.

Will then submit fixes - further testing shows that pull request #70 does not solve the problem properly.

Fixes #69