### PR TITLE
Check Local Connection in parseVersion2

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -522,6 +522,18 @@ func TestFormatInvalid(t *testing.T) {
 			},
 			err: ErrInvalidAddress,
 		},
+		{
+			name: "v2mismatchProxy_Protocol",
+			header: &Header{
+				Version:           2,
+				Command:           PROXY,
+				TransportProtocol: UNSPEC,
+				SourceAddr:        v4UDPAddr,
+				DestinationAddr:   unixStreamAddr,
+				rawTLVs:           make([]byte, 1<<16),
+			},
+			err: errUint16Overflow,
+		},
 	}
 
 	for _, test := range tests {

--- a/v2.go
+++ b/v2.go
@@ -111,9 +111,8 @@ func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
 		return nil, ErrInvalidLength
 	}
 
-	// if local then we should just skip the rest of the header as per spec
-	// 	When a sender presents a LOCAL connection, it should not present any
-	// address so it sets this field to zero. Receivers MUST always consider
+	// When a sender presents a LOCAL connection, it should not present any address
+	// so it sets this field to zero. Receivers MUST always consider
 	// this field to skip the appropriate number of bytes and must not assume
 	// zero is presented for LOCAL connections.
 	if header.Command.IsLocal() {

--- a/v2.go
+++ b/v2.go
@@ -120,6 +120,7 @@ func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
 		if _, err := reader.Discard(int(length)); err != nil {
 			return nil, ErrInvalidAddress
 		}
+
 		return header, nil
 	}
 
@@ -180,6 +181,12 @@ func (header *Header) formatVersion2() ([]byte, error) {
 	buf.Write(SIGV2)
 	buf.WriteByte(header.Command.toByte())
 	buf.WriteByte(header.TransportProtocol.toByte())
+
+	if header.Command.IsLocal() {
+		buf.Write([]byte{'\x00', '\x00'})
+		return buf.Bytes(), nil
+	}
+
 	if header.TransportProtocol.IsUnspec() {
 		// For UNSPEC, write no addresses and ports but only TLVs if they are present
 		hdrLen, err := addTLVLen(lengthUnspecBytes, len(header.rawTLVs))

--- a/v2_test.go
+++ b/v2_test.go
@@ -171,13 +171,13 @@ var validParseAndWriteV2Tests = []struct {
 			Version:           2,
 			Command:           LOCAL,
 			TransportProtocol: TCPv4,
-			SourceAddr:        v4addr,
-			DestinationAddr:   v4addr,
+			SourceAddr:        nil,
+			DestinationAddr:   nil,
 		},
 	},
 	{
 		desc:   "local unspec",
-		reader: newBufioReader(append(append(SIGV2, byte(LOCAL), byte(UNSPEC)), fixtureIPv4V2...)),
+		reader: newBufioReader(append(append(SIGV2, byte(LOCAL), byte(UNSPEC)), lengthUnspecBytes...)),
 		expectedHeader: &Header{
 			Version:           2,
 			Command:           LOCAL,
@@ -186,6 +186,7 @@ var validParseAndWriteV2Tests = []struct {
 			DestinationAddr:   nil,
 		},
 	},
+
 	{
 		desc:   "proxy TCPv4",
 		reader: newBufioReader(append(append(SIGV2, byte(PROXY), byte(TCPv4)), fixtureIPv4V2...)),
@@ -232,6 +233,7 @@ var validParseAndWriteV2Tests = []struct {
 			rawTLVs:           fixtureTLV,
 		},
 	},
+
 	{
 		desc:   "local unspec with TLV",
 		reader: newBufioReader(append(append(SIGV2, byte(LOCAL), byte(UNSPEC)), fixtureUnspecTLV...)),
@@ -241,7 +243,6 @@ var validParseAndWriteV2Tests = []struct {
 			TransportProtocol: UNSPEC,
 			SourceAddr:        nil,
 			DestinationAddr:   nil,
-			rawTLVs:           fixtureTLV,
 		},
 	},
 	{
@@ -480,17 +481,6 @@ var tlvFormatTests = []struct {
 			TransportProtocol: UDPv6,
 			SourceAddr:        v6addr,
 			DestinationAddr:   v6addr,
-			rawTLVs:           make([]byte, 1<<16),
-		},
-	},
-	{
-		desc: "local unspec",
-		header: &Header{
-			Version:           2,
-			Command:           LOCAL,
-			TransportProtocol: UNSPEC,
-			SourceAddr:        nil,
-			DestinationAddr:   nil,
 			rawTLVs:           make([]byte, 1<<16),
 		},
 	},

--- a/v2_test.go
+++ b/v2_test.go
@@ -177,7 +177,7 @@ var validParseAndWriteV2Tests = []struct {
 	},
 	{
 		desc:   "local unspec",
-		reader: newBufioReader(append(append(SIGV2, byte(LOCAL), byte(UNSPEC)), lengthUnspecBytes...)),
+		reader: newBufioReader(append(append(SIGV2, byte(LOCAL), byte(UNSPEC)), fixtureIPv4V2...)),
 		expectedHeader: &Header{
 			Version:           2,
 			Command:           LOCAL,


### PR DESCRIPTION
If Connection is LOCAL then we should just skip the rest of the header as per spec. When a sender presents a LOCAL connection, it should not present any address so it sets this field to zero. Receivers MUST always consider this field to skip the appropriate number of bytes and must not assume zero is presented for LOCAL connections.