### PR TITLE
Bump DefaultReadHeaderTimeout to 10s

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -12,7 +12,7 @@ import (
 // be read from the wire, if Listener.ReaderHeaderTimeout is not set.
 // It's kept as a global variable so to make it easier to find and override,
 // e.g. go build -ldflags -X "github.com/pires/go-proxyproto.DefaultReadHeaderTimeout=1s"
-var DefaultReadHeaderTimeout = 200 * time.Millisecond
+var DefaultReadHeaderTimeout = 10 * time.Second
 
 // Listener is used to wrap an underlying listener,
 // whose connections may be using the HAProxy Proxy Protocol.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -265,6 +265,8 @@ func TestReadHeaderTimeoutIsReset(t *testing.T) {
 // we expect the actual address and port to be returned,
 // rather than the ProxyHeader we defined.
 func TestReadHeaderTimeoutIsEmpty(t *testing.T) {
+	DefaultReadHeaderTimeout = 200 * time.Millisecond
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
When dealing with slow networks and TLS, 200ms is often hit. Bump
the default timeout to 10s, which is what crupto/tls uses for the
TLS handshake.

Closes: https://github.com/pires/go-proxyproto/issues/83