### PR TITLE
Allow IPv6 compat addresses (4in6) when parsing TCPv6 in V1 header 

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -13,20 +13,23 @@ import (
 // Stuff to be used in both versions tests.
 
 const (
-	NO_PROTOCOL   = "There is no spoon"
-	IP4_ADDR      = "127.0.0.1"
-	IP6_ADDR      = "::1"
-	IP6_LONG_ADDR = "1234:5678:9abc:def0:cafe:babe:dead:2bad"
-	PORT          = 65533
-	INVALID_PORT  = 99999
+	NO_PROTOCOL     = "There is no spoon"
+	IP4_ADDR        = "127.0.0.1"
+	IP6_ADDR        = "::1"
+	IP6_LONG_ADDR   = "1234:5678:9abc:def0:cafe:babe:dead:2bad"
+	IP6_COMPAT_ADDR = "0:0:0:0:0:ffff:7f00:1"
+	PORT            = 65533
+	INVALID_PORT    = 99999
 )
 
 var (
-	v4ip = net.ParseIP(IP4_ADDR).To4()
-	v6ip = net.ParseIP(IP6_ADDR).To16()
+	v4ip       = net.ParseIP(IP4_ADDR).To4()
+	v6ip       = net.ParseIP(IP6_ADDR).To16()
+	v6CompatIP = net.ParseIP(IP4_ADDR).To16()
 
-	v4addr net.Addr = &net.TCPAddr{IP: v4ip, Port: PORT}
-	v6addr net.Addr = &net.TCPAddr{IP: v6ip, Port: PORT}
+	v4addr       net.Addr = &net.TCPAddr{IP: v4ip, Port: PORT}
+	v6addr       net.Addr = &net.TCPAddr{IP: v6ip, Port: PORT}
+	v6CompatAddr net.Addr = &net.TCPAddr{IP: v6CompatIP, Port: PORT}
 
 	v4UDPAddr net.Addr = &net.UDPAddr{IP: v4ip, Port: PORT}
 	v6UDPAddr net.Addr = &net.UDPAddr{IP: v6ip, Port: PORT}

--- a/v1.go
+++ b/v1.go
@@ -221,11 +221,16 @@ func parseV1PortNumber(portStr string) (int, error) {
 	return port, nil
 }
 
-func parseV1IPAddress(protocol AddressFamilyAndProtocol, addrStr string) (addr net.IP, err error) {
-	addr = net.ParseIP(addrStr)
-	tryV4 := addr.To4()
-	if (protocol == TCPv4 && tryV4 == nil) || (protocol == TCPv6 && tryV4 != nil) {
-		err = ErrInvalidAddress
+func parseV1IPAddress(protocol AddressFamilyAndProtocol, addrStr string) (net.IP, error) {
+	ip := net.ParseIP(addrStr)
+	switch protocol {
+	case TCPv4:
+		ip = ip.To4()
+	case TCPv6:
+		ip = ip.To16()
 	}
-	return
+	if ip == nil {
+		return nil, ErrInvalidAddress
+	}
+	return ip, nil
 }

--- a/v1_test.go
+++ b/v1_test.go
@@ -16,7 +16,7 @@ var (
 	IPv4AddressesAndInvalidPorts = strings.Join([]string{IP4_ADDR, IP4_ADDR, strconv.Itoa(INVALID_PORT), strconv.Itoa(INVALID_PORT)}, separator)
 	IPv6AddressesAndPorts        = strings.Join([]string{IP6_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
 	IPv6LongAddressesAndPorts    = strings.Join([]string{IP6_LONG_ADDR, IP6_LONG_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
-	TCP6CompatAddressesAndPorts  = strings.Join([]string{IP6_COMPAT_ADDR, IP6_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
+	TCP6CompatAddressesAndPorts  = strings.Join([]string{IP6_COMPAT_ADDR, IP6_COMPAT_ADDR, strconv.Itoa(PORT), strconv.Itoa(PORT)}, separator)
 
 	fixtureTCP4V1 = "PROXY TCP4 " + IPv4AddressesAndPorts + crlf + "GET /"
 	fixtureTCP6V1 = "PROXY TCP6 " + IPv6AddressesAndPorts + crlf + "GET /"
@@ -69,11 +69,11 @@ var invalidParseV1Tests = []struct {
 		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv4AddressesAndPorts)),
 		expectedError: ErrCantReadVersion1Header,
 	},
-	//{
-	//	desc:          "TCP6 with IPv4 addresses",
-	//	reader:        newBufioReader([]byte("PROXY TCP6 " + IPv4AddressesAndPorts + crlf)),
-	//	expectedError: ErrInvalidAddress,
-	//},
+	{
+		desc:          "TCP6 with IPv4 addresses",
+		reader:        newBufioReader([]byte("PROXY TCP6 " + IPv4AddressesAndPorts + crlf)),
+		expectedError: ErrInvalidAddress,
+	},
 	{
 		desc:          "TCP4 with IPv6 addresses",
 		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv6AddressesAndPorts + crlf)),
@@ -158,7 +158,7 @@ var validParseAndWriteV1Tests = []struct {
 			Command:           PROXY,
 			TransportProtocol: TCPv6,
 			SourceAddr:        v6CompatAddr,
-			DestinationAddr:   v6addr,
+			DestinationAddr:   v6CompatAddr,
 		},
 	},
 }


### PR DESCRIPTION
This is a follow-up on MR #49 by @emersion . All credits should go to him :)

I had a need to parse 4in6 addresses myself as well, so I took his MR as a starting point and took it from there. I have not yet tested this code in production, but I figured I'd already turn it into a PR.

There is one issue that I had to sort of work around: In the default net.IP library, an IPv4 address is (or can be) stored more or less in the same way an IPv6 address is stored with a ::FFFF: prefix. As such, there's no way to make a distinction based on a net.IP object if it was an IPv4 address, or IPv6 4in6 address. 