### PR TITLE
policy: add REFUSE

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -51,6 +51,9 @@ const (
 	// Note: an example usage can be found in the SkipProxyHeaderForCIDR
 	// function.
 	SKIP
+	// REFUSE is the same as REJECT if a proxy header is set and the same as
+	// REQUIRE if a proxy header is not set.
+	REFUSE
 )
 
 // SkipProxyHeaderForCIDR returns a PolicyFunc which can be used to accept a
@@ -117,7 +120,7 @@ func StrictWhiteListPolicy(allowed []string) (PolicyFunc, error) {
 		return nil, err
 	}
 
-	return whitelistPolicy(allowFrom, REJECT), nil
+	return whitelistPolicy(allowFrom, REFUSE), nil
 }
 
 // MustStrictWhiteListPolicy returns a StrictWhiteListPolicy but will panic

--- a/policy_test.go
+++ b/policy_test.go
@@ -42,8 +42,8 @@ func TestStrictWhitelistPolicyReturnsRejectWhenUpstreamIpAddrNotInWhitelist(t *t
 		t.Fatalf("err: %v", err)
 	}
 
-	if policy != REJECT {
-		t.Fatalf("Expected policy REJECT, got %v", policy)
+	if policy != REFUSE {
+		t.Fatalf("Expected policy REFUSE, got %v", policy)
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -288,7 +288,7 @@ func (p *Conn) readHeader() error {
 	// let's act as if there was no error when PROXY protocol is not present.
 	if err == ErrNoProxyProtocol {
 		// but not if it is required that the connection has one
-		if p.ProxyHeaderPolicy == REQUIRE {
+		if p.ProxyHeaderPolicy == REQUIRE || p.ProxyHeaderPolicy == REFUSE {
 			return err
 		}
 
@@ -298,7 +298,7 @@ func (p *Conn) readHeader() error {
 	// proxy protocol header was found
 	if err == nil && header != nil {
 		switch p.ProxyHeaderPolicy {
-		case REJECT:
+		case REJECT, REFUSE:
 			// this connection is not allowed to send one
 			return ErrSuperfluousProxyHeader
 		case USE, REQUIRE:


### PR DESCRIPTION
in strict whitelist policies we want to refuse a connection from a not allowed upstream address whether the proxy header is set or not set.

Before this change if the upstream address is not allowed:

1) if the policy returns REJECT, the connection is allowed if no proxy
   header is sent
2) if the policy returns REQUIRE, the connection is allowed if a proxy
   header is set, even if the upstream address is not allowed to set it.

The new REFUSE policy can be returned for not allowed addresses so that the connection is always refused.