### PR TITLE
protocol: avoid double buffering

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -134,8 +134,13 @@ func (p *Listener) Addr() net.Addr {
 // NewConn is used to wrap a net.Conn that may be speaking
 // the proxy protocol into a proxyproto.Conn
 func NewConn(conn net.Conn, opts ...func(*Conn)) *Conn {
+	// For v1 the header length is at most 108 bytes.
+	// For v2 the header length is at most 52 bytes plus the length of the TLVs.
+	// We use 256 bytes to be safe.
+	const bufSize = 256
+
 	pConn := &Conn{
-		bufReader: bufio.NewReader(conn),
+		bufReader: bufio.NewReaderSize(conn, bufSize),
 		conn:      conn,
 	}
 

--- a/protocol.go
+++ b/protocol.go
@@ -43,10 +43,10 @@ type Conn struct {
 	once              sync.Once
 	readErr           error
 	conn              net.Conn
-	Validate          Validator
 	bufReader         *bufio.Reader
 	header            *Header
 	ProxyHeaderPolicy Policy
+	Validate          Validator
 	readHeaderTimeout time.Duration
 }
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 	"time"
@@ -1480,7 +1479,7 @@ type testConn struct {
 
 func (c *testConn) ReadFrom(r io.Reader) (int64, error) {
 	c.readFromCalledWith = r
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	return int64(len(b)), err
 }
 func (c *testConn) Write(p []byte) (int, error) {
@@ -1625,7 +1624,7 @@ func benchmarkTCPProxy(size int, b *testing.B) {
 
 		}()
 		//receive data
-		n, err := io.Copy(ioutil.Discard, conn)
+		n, err := io.Copy(io.Discard, conn)
 		if n != int64(len(data)) {
 			b.Fatalf("Expected to receive %d bytes, got %d", len(data), n)
 		}


### PR DESCRIPTION
Use smaller buffer size, and use buffer only to read the PROXY header.

Users may use they own buffers with they own buffer sizes and pools - connection should respect that.