### PR TITLE
Fix Go Documentation of Default timeout

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -28,7 +28,7 @@ var (
 // If the connection is using the protocol, the RemoteAddr() will return
 // the correct client address. ReadHeaderTimeout will be applied to all
 // connections in order to prevent blocking operations. If no ReadHeaderTimeout
-// is set, a default of 200ms will be used. This can be disabled by setting the
+// is set, a default of 10s will be used. This can be disabled by setting the
 // timeout to < 0.
 //
 // Only one of Policy or ConnPolicy should be provided. If both are provided then

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -296,8 +296,8 @@ func TestReadHeaderTimeoutIsReset(t *testing.T) {
 }
 
 // TestReadHeaderTimeoutIsEmpty ensures the default is set if it is empty.
-// Because the default is 200ms and we wait longer than that to send a message,
-// we expect the actual address and port to be returned,
+// The default is 10s, but we delay sending a message, so use 200ms in this test.
+// We expect the actual address and port to be returned,
 // rather than the ProxyHeader we defined.
 func TestReadHeaderTimeoutIsEmpty(t *testing.T) {
 	DefaultReadHeaderTimeout = 200 * time.Millisecond


### PR DESCRIPTION
With commit 7f1f93d the default timeout was changed from 200ms to 10s however the Go Documentation still shows the old default.

This commit fixes that, also I clarified in the protocol_test.go why the DefaultReadHeader is changed to 200ms.


No extra tests are needed since there is no Go code added, changed or removed.