### PR TITLE
Increase read buffer size to capture the full possible size of a header.

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -153,8 +153,8 @@ func (p *Listener) Addr() net.Addr {
 func NewConn(conn net.Conn, opts ...func(*Conn)) *Conn {
 	// For v1 the header length is at most 108 bytes.
 	// For v2 the header length is at most 52 bytes plus the length of the TLVs.
-	// We use 256 bytes to be safe.
-	const bufSize = 256
+	// We use 65535, as it's the maximum length representable by a uint16.
+	const bufSize = 65535
 	br := bufio.NewReaderSize(conn, bufSize)
 
 	pConn := &Conn{


### PR DESCRIPTION
I don't know what the original motivation was for reducing the buffer size and I'm open to other strategies, but it seems that the changes that [set the smaller buffer](https://github.com/pires/go-proxyproto/commit/917127059a4a27da09b29fc25d367e81fd88b5aa) and [did away with the multi reader](https://github.com/pires/go-proxyproto/commit/2df67b4704aa55bdc60e50b75337678625b64c39) have made it so that any header with total length >256 will fail to parse. Any content byte length up to the maximum representable with a 16 bit integer should be valid and should parse.
