### PR TITLE
Use same bufio.Reader size for NewConn and for tests

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+// readBufferSize is the size used for bufio.Reader's internal buffer.
+//
+// For v1 the header length is at most 108 bytes.
+// For v2 the header length is at most 52 bytes plus the length of the TLVs.
+// We use 256 bytes to be safe.
+const readBufferSize = 256
+
 var (
 	// DefaultReadHeaderTimeout is how long header processing waits for header to
 	// be read from the wire, if Listener.ReaderHeaderTimeout is not set.
@@ -153,11 +160,7 @@ func (p *Listener) Addr() net.Addr {
 // NewConn is used to wrap a net.Conn that may be speaking
 // the proxy protocol into a proxyproto.Conn.
 func NewConn(conn net.Conn, opts ...func(*Conn)) *Conn {
-	// For v1 the header length is at most 108 bytes.
-	// For v2 the header length is at most 52 bytes plus the length of the TLVs.
-	// We use 256 bytes to be safe.
-	const bufSize = 256
-	br := bufio.NewReaderSize(conn, bufSize)
+	br := bufio.NewReaderSize(conn, readBufferSize)
 
 	pConn := &Conn{
 		bufReader: br,

--- a/v2_test.go
+++ b/v2_test.go
@@ -318,7 +318,7 @@ func TestWriteV2Valid(t *testing.T) {
 			}
 
 			// Read written bytes to validate written header
-			r := bufio.NewReader(&b)
+			r := bufio.NewReaderSize(&b, readBufferSize)
 			newHeader, err := Read(r)
 			if err != nil {
 				t.Fatal("unexpected error ", err)
@@ -511,7 +511,7 @@ func TestV2TLVFormatTooLargeTLV(t *testing.T) {
 }
 
 func newBufioReader(b []byte) *bufio.Reader {
-	return bufio.NewReader(bytes.NewReader(b))
+	return bufio.NewReaderSize(bytes.NewReader(b), readBufferSize)
 }
 
 func fixtureWithTLV(cur []byte, addr []byte, tlv []byte) []byte {


### PR DESCRIPTION
Right now, NewConn creates a bufio.Reader with a 256 bytes buffer
size, but Read tests use the default buffer size (4KiB). Align
these two so that we catch any bug related to a low buffer size in
tests.

_See individual commits._