### PR TITLE
http2: return http.ErrServerClosed in Server.Serve

### DIFF
--- a/helper/http2/http2.go
+++ b/helper/http2/http2.go
@@ -106,6 +106,9 @@ func (srv *Server) Serve(ln net.Listener) error {
 			srv.errorLog().Printf("listener %q: accept error (retrying in %v): %v", ln.Addr(), delay, err)
 			time.Sleep(delay)
 		} else if err != nil {
+			if srv.isClosed() {
+				return http.ErrServerClosed
+			}
 			return fmt.Errorf("failed to accept connection: %w", err)
 		}
 
@@ -196,6 +199,12 @@ func (srv *Server) closeListeners() error {
 		}
 	}
 	return err
+}
+
+func (srv *Server) isClosed() bool {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	return srv.closed
 }
 
 // h1Listener is used to signal back http.Server's Close and Shutdown to the

--- a/helper/http2/http2_test.go
+++ b/helper/http2/http2_test.go
@@ -190,7 +190,7 @@ func newTestServer(t *testing.T) (addr string, server *http.Server) {
 
 	t.Cleanup(func() {
 		err := <-done
-		if err != nil && !errors.Is(err, net.ErrClosed) {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Fatalf("failed to serve: %v", err)
 		}
 	})
@@ -231,7 +231,7 @@ func newTLSTestServer(t *testing.T) (addr string, server *http.Server) {
 
 	t.Cleanup(func() {
 		err := <-done
-		if err != nil && !errors.Is(err, net.ErrClosed) {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Fatalf("failed to serve: %v", err)
 		}
 	})


### PR DESCRIPTION
Mimick what net/http does:

https://github.com/golang/go/blob/99d7121934a9cfa7963d3a9bfd840779fd2869f6/src/net/http/server.go#L3448