### PR TITLE
v1: accept plain IPv4 addresses in TCP6 headers

### DIFF
--- a/examples/httpserver/httpserver.go
+++ b/examples/httpserver/httpserver.go
@@ -23,7 +23,7 @@ func main() {
 			}
 		},
 		Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-			log.Printf("[Handler] remote ip %q", r.RemoteAddr)
+			log.Printf("[Handler] remote ip %q", r.RemoteAddr) //nolint:gosec // G706: RemoteAddr is logged intentionally
 		}),
 	}
 

--- a/v1.go
+++ b/v1.go
@@ -237,12 +237,20 @@ func parseV1IPAddress(protocol AddressFamilyAndProtocol, addrStr string) (net.IP
 			return net.IP(addr.AsSlice()), nil
 		}
 	case TCPv6:
+		// Some proxies (notably nginx OSS stream module) emit plain IPv4
+		// addresses in TCP6 headers when the backend is IPv4 but the client
+		// is IPv6. Promote to IPv4-mapped IPv6 for interoperability.
+		//
+		// This is an intentional departure from the PROXY protocol v1 spec,
+		// which states that addresses in a TCP6 line must be in IPv6 format.
 		if addr.Is6() || addr.Is4In6() {
 			return net.IP(addr.AsSlice()), nil
 		}
+		// ATTENTION: this is a lossy conversion — round-trip serialization will
+		// render the address as "::ffff:x.x.x.x" rather than the original "x.x.x.x".
 		if addr.Is4() {
-			a16 := addr.As16()
-			return net.IP(a16[:]), nil
+			mapped := netip.AddrFrom16(addr.As16())
+			return net.IP(mapped.AsSlice()), nil
 		}
 	}
 

--- a/v1.go
+++ b/v1.go
@@ -240,6 +240,10 @@ func parseV1IPAddress(protocol AddressFamilyAndProtocol, addrStr string) (net.IP
 		if addr.Is6() || addr.Is4In6() {
 			return net.IP(addr.AsSlice()), nil
 		}
+		if addr.Is4() {
+			a16 := addr.As16()
+			return net.IP(a16[:]), nil
+		}
 	}
 
 	return nil, ErrInvalidAddress

--- a/v1_test.go
+++ b/v1_test.go
@@ -29,9 +29,9 @@ var (
 	fixtureUnknown              = "PROXY UNKNOWN" + crlf
 	fixtureUnknownWithAddresses = "PROXY UNKNOWN " + IPv4AddressesAndInvalidPorts + crlf
 
-	fixtureTCP4Simple         = "PROXY TCP4 1.2.3.4 5.6.7.8 12345 22" + crlf
+	fixtureTCP6IPv4SrcIPv4Dst = "PROXY TCP6 192.0.2.1 192.0.2.2 1234 5678" + crlf
 	fixtureTCP6IPv6SrcIPv4Dst = "PROXY TCP6 2001:db8::1 192.0.2.1 51512 22" + crlf
-	fixtureTCP6Loopback       = "PROXY TCP6 ::1 ::1 1234 5678" + crlf
+	fixtureTCP6IPv4SrcIPv6Dst = "PROXY TCP6 192.0.2.1 2001:db8::1 51512 22" + crlf
 )
 
 var invalidParseV1Tests = []struct {
@@ -87,6 +87,11 @@ var invalidParseV1Tests = []struct {
 	{
 		desc:          "TCP4 with IPv4 mapped addresses",
 		reader:        newBufioReader([]byte("PROXY TCP4 " + IPv4In6AddressesAndPorts + crlf)),
+		expectedError: ErrInvalidAddress,
+	},
+	{
+		desc:          "TCP6 with invalid address",
+		reader:        newBufioReader([]byte("PROXY TCP6 not-an-ip ::1 1234 5678" + crlf)),
 		expectedError: ErrInvalidAddress,
 	},
 	{
@@ -177,18 +182,19 @@ var validParseAndWriteV1Tests = []struct {
 		},
 	},
 	{
-		desc:   "TCP4 simple",
-		reader: bufio.NewReader(strings.NewReader(fixtureTCP4Simple)),
+		desc:   "TCP6 IPv4 src IPv4 dst",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP6IPv4SrcIPv4Dst)),
 		expectedHeader: &Header{
 			Version:           1,
 			Command:           PROXY,
-			TransportProtocol: TCPv4,
-			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("1.2.3.4").To4(), Port: 12345},
-			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("5.6.7.8").To4(), Port: 22},
+			TransportProtocol: TCPv6,
+			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("192.0.2.1").To16(), Port: 1234},
+			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("192.0.2.2").To16(), Port: 5678},
 		},
+		skipWrite: true,
 	},
 	{
-		desc:   "TCP6 IPv6 src IPv4 dst mixed",
+		desc:   "TCP6 IPv6 src IPv4 dst",
 		reader: bufio.NewReader(strings.NewReader(fixtureTCP6IPv6SrcIPv4Dst)),
 		expectedHeader: &Header{
 			Version:           1,
@@ -200,15 +206,16 @@ var validParseAndWriteV1Tests = []struct {
 		skipWrite: true,
 	},
 	{
-		desc:   "TCP6 loopback",
-		reader: bufio.NewReader(strings.NewReader(fixtureTCP6Loopback)),
+		desc:   "TCP6 IPv4 src IPv6 dst",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP6IPv4SrcIPv6Dst)),
 		expectedHeader: &Header{
 			Version:           1,
 			Command:           PROXY,
 			TransportProtocol: TCPv6,
-			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("::1").To16(), Port: 1234},
-			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("::1").To16(), Port: 5678},
+			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("192.0.2.1").To16(), Port: 51512},
+			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("2001:db8::1").To16(), Port: 22},
 		},
+		skipWrite: true,
 	},
 }
 

--- a/v1_test.go
+++ b/v1_test.go
@@ -28,6 +28,10 @@ var (
 
 	fixtureUnknown              = "PROXY UNKNOWN" + crlf
 	fixtureUnknownWithAddresses = "PROXY UNKNOWN " + IPv4AddressesAndInvalidPorts + crlf
+
+	fixtureTCP4Simple         = "PROXY TCP4 1.2.3.4 5.6.7.8 12345 22" + crlf
+	fixtureTCP6IPv6SrcIPv4Dst = "PROXY TCP6 2001:db8::1 192.0.2.1 51512 22" + crlf
+	fixtureTCP6Loopback       = "PROXY TCP6 ::1 ::1 1234 5678" + crlf
 )
 
 var invalidParseV1Tests = []struct {
@@ -73,11 +77,6 @@ var invalidParseV1Tests = []struct {
 	{
 		desc:          "invalid IP address",
 		reader:        newBufioReader([]byte("PROXY TCP4 invalid invalid 65533 65533" + crlf)),
-		expectedError: ErrInvalidAddress,
-	},
-	{
-		desc:          "TCP6 with IPv4 addresses",
-		reader:        newBufioReader([]byte("PROXY TCP6 " + IPv4AddressesAndPorts + crlf)),
 		expectedError: ErrInvalidAddress,
 	},
 	{
@@ -175,6 +174,40 @@ var validParseAndWriteV1Tests = []struct {
 			TransportProtocol: UNSPEC,
 			SourceAddr:        nil,
 			DestinationAddr:   nil,
+		},
+	},
+	{
+		desc:   "TCP4 simple",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP4Simple)),
+		expectedHeader: &Header{
+			Version:           1,
+			Command:           PROXY,
+			TransportProtocol: TCPv4,
+			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("1.2.3.4").To4(), Port: 12345},
+			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("5.6.7.8").To4(), Port: 22},
+		},
+	},
+	{
+		desc:   "TCP6 IPv6 src IPv4 dst mixed",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP6IPv6SrcIPv4Dst)),
+		expectedHeader: &Header{
+			Version:           1,
+			Command:           PROXY,
+			TransportProtocol: TCPv6,
+			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("2001:db8::1").To16(), Port: 51512},
+			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("192.0.2.1").To16(), Port: 22},
+		},
+		skipWrite: true,
+	},
+	{
+		desc:   "TCP6 loopback",
+		reader: bufio.NewReader(strings.NewReader(fixtureTCP6Loopback)),
+		expectedHeader: &Header{
+			Version:           1,
+			Command:           PROXY,
+			TransportProtocol: TCPv6,
+			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("::1").To16(), Port: 1234},
+			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("::1").To16(), Port: 5678},
 		},
 	},
 }


### PR DESCRIPTION
## Problem

When proxying SSH connections through a chain involving nginx's OSS stream module, PROXY protocol v1 headers with mixed address families are emitted and currently rejected by this library.

The chain looks like:

```
IPv6 client → Cloudflare Spectrum (PROXY v2) → nginx stream (decodes v2, re-encodes as v1) → application (go-proxyproto)
```

nginx's OSS stream module (`proxy_protocol on`) always re-encodes as PROXY protocol v1. When the original client is IPv6 but the backend is IPv4, nginx emits:

```
PROXY TCP6 2001:db8::1 192.0.2.1 51512 22\r\n
```

This is technically outside the strict spec (which says both addresses in a `TCP6` header should be in IPv6 format), but it is the real-world output of a widely deployed proxy and there is no workaround available in nginx OSS.

go-proxyproto was returning `proxyproto: invalid address` for these headers, causing the connection to fail. IPv4-only connections worked fine.

## Root Cause

`parseV1IPAddress` in `v1.go` handled `TCPv6` by accepting addresses where `addr.Is6()` or `addr.Is4In6()` (i.e. `::ffff:x.x.x.x` notation). A plain IPv4 address like `192.0.2.1` parses as `addr.Is4()` -- neither condition matched, so it fell through to `ErrInvalidAddress`.

## Fix

When parsing a `TCPv6` header and the address is a plain IPv4, promote it to a 16-byte IPv4-mapped-IPv6 representation via `netip.AddrFrom16(addr.As16())`. This is consistent with how `net.IP.To16()` works elsewhere in the library and produces a valid `net.IP` that callers can use normally.

Note: this is a lossy conversion -- round-trip serialization will render the address as `::ffff:x.x.x.x` rather than the original `x.x.x.x`.

## Tests

- Added `"TCP6 with invalid address"` test case (`PROXY TCP6 not-an-ip ::1 1234 5678`)
- Added three new valid parse cases covering mixed address families in TCP6 headers:
  - `PROXY TCP6 192.0.2.1 192.0.2.2 1234 5678` -- IPv4 src, IPv4 dst
  - `PROXY TCP6 2001:db8::1 192.0.2.1 51512 22` -- IPv6 src, IPv4 dst (the nginx mixed case)
  - `PROXY TCP6 192.0.2.1 2001:db8::1 51512 22` -- IPv4 src, IPv6 dst
- All mixed-address test cases use `skipWrite: true` since round-trip serialization changes the address representation
- Removed duplicate test fixtures that were identical to existing `fixtureTCP4V1` and `fixtureTCP6V1`

## Notes

- PROXY protocol v2 is **not affected** -- v2 is binary and reads fixed-width 16-byte address fields directly, so mixed address families cannot arise in the same way
- No API changes; downstream consumers need only bump their dependency to pick up the fix
- This code was developed in part with [GitLab Duo](https://about.gitlab.com/gitlab-duo/)