### PR TITLE
header: use bytes.Reader instead of bytes.Buffer

### DIFF
--- a/header.go
+++ b/header.go
@@ -199,7 +199,7 @@ func (header *Header) WriteTo(w io.Writer) (int64, error) {
 		return 0, err
 	}
 
-	return bytes.NewBuffer(buf).WriteTo(w)
+	return bytes.NewReader(buf).WriteTo(w)
 }
 
 // Format renders a proxy protocol header in a format to write over the wire.

--- a/header.go
+++ b/header.go
@@ -225,7 +225,7 @@ func (header *Header) WriteTo(w io.Writer) (int64, error) {
 		return 0, err
 	}
 
-	return bytes.NewBuffer(buf).WriteTo(w)
+	return bytes.NewReader(buf).WriteTo(w)
 }
 
 // Format renders a proxy protocol header in a format to write over the wire.


### PR DESCRIPTION
Use bytes.Reader instead of bytes.Buffer.