### PR TITLE
Improve IP address handling for v1 and version detection

### DIFF
--- a/header.go
+++ b/header.go
@@ -78,21 +78,25 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 	}
 	switch sourceAddr := sourceAddr.(type) {
 	case *net.TCPAddr:
-		if _, ok := destAddr.(*net.TCPAddr); !ok {
+		destAddr, ok := destAddr.(*net.TCPAddr)
+		if !ok {
 			break
 		}
-		if len(sourceAddr.IP.To4()) == net.IPv4len {
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = TCPv4
-		} else if len(sourceAddr.IP) == net.IPv6len {
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
 			h.TransportProtocol = TCPv6
 		}
 	case *net.UDPAddr:
-		if _, ok := destAddr.(*net.UDPAddr); !ok {
+		destAddr, ok := destAddr.(*net.UDPAddr)
+		if !ok {
 			break
 		}
-		if len(sourceAddr.IP.To4()) == net.IPv4len {
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = UDPv4
-		} else if len(sourceAddr.IP) == net.IPv6len {
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
 			h.TransportProtocol = UDPv6
 		}
 	case *net.UnixAddr:

--- a/header.go
+++ b/header.go
@@ -85,21 +85,25 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 	}
 	switch sourceAddr := sourceAddr.(type) {
 	case *net.TCPAddr:
-		if _, ok := destAddr.(*net.TCPAddr); !ok {
+		destAddr, ok := destAddr.(*net.TCPAddr)
+		if !ok {
 			break
 		}
-		if len(sourceAddr.IP.To4()) == net.IPv4len {
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = TCPv4
-		} else if len(sourceAddr.IP) == net.IPv6len {
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
 			h.TransportProtocol = TCPv6
 		}
 	case *net.UDPAddr:
-		if _, ok := destAddr.(*net.UDPAddr); !ok {
+		destAddr, ok := destAddr.(*net.UDPAddr)
+		if !ok {
 			break
 		}
-		if len(sourceAddr.IP.To4()) == net.IPv4len {
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = UDPv4
-		} else if len(sourceAddr.IP) == net.IPv6len {
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
 			h.TransportProtocol = UDPv6
 		}
 	case *net.UnixAddr:

--- a/v1.go
+++ b/v1.go
@@ -184,16 +184,16 @@ func (header *Header) formatVersion1() ([]byte, error) {
 		return nil, ErrInvalidAddress
 	}
 
-	sourceIP, destIP := sourceAddr.IP, destAddr.IP
+	var sourceIP, destIP netip.Addr
 	switch header.TransportProtocol {
 	case TCPv4:
-		sourceIP = sourceIP.To4()
-		destIP = destIP.To4()
+		sourceIP, _ = netip.AddrFromSlice(sourceAddr.IP.To4())
+		destIP, _ = netip.AddrFromSlice(destAddr.IP.To4())
 	case TCPv6:
-		sourceIP = sourceIP.To16()
-		destIP = destIP.To16()
+		sourceIP, _ = netip.AddrFromSlice(sourceAddr.IP.To4())
+		destIP, _ = netip.AddrFromSlice(destAddr.IP.To4())
 	}
-	if sourceIP == nil || destIP == nil {
+	if !sourceIP.IsValid() || !destIP.IsValid() {
 		return nil, ErrInvalidAddress
 	}
 

--- a/v1.go
+++ b/v1.go
@@ -190,16 +190,18 @@ func (header *Header) formatVersion1() ([]byte, error) {
 		return nil, ErrInvalidAddress
 	}
 
-	sourceIP, destIP := sourceAddr.IP, destAddr.IP
+	var sourceIP, destIP netip.Addr
 	switch header.TransportProtocol {
 	case TCPv4:
-		sourceIP = sourceIP.To4()
-		destIP = destIP.To4()
+		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To4())
+		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To4())
 	case TCPv6:
-		sourceIP = sourceIP.To16()
-		destIP = destIP.To16()
+		// Use netip.Addr instead net.IP so to guarantee Is6() address, ie a v4-mapped IP in a TCP6 header
+		// serializes as ::ffff:1.2.3.4 instead of net.IP.String()'s collapsed 1.2.3.4.
+		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To16())
+		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To16())
 	}
-	if sourceIP == nil || destIP == nil {
+	if !sourceOK || !destOK {
 		return nil, ErrInvalidAddress
 	}
 


### PR DESCRIPTION
The standard `net.IP` implementation inconsistently represents IPv4-mapped IPv6 addresses; its `String()` method returns an IPv4 string for mapped addresses, which causes formatting issues in v1 headers where strict version representation is required. (#167)

This patch migrates IP state management to `netip.Addr` to ensure that `String()` outputs and byte representations strictly follow the expected protocol format.

Additionally, this fix addresses a bug in the header construction logic. 

The previous implementation only verified the source IP version, leading to incorrect protocol family assignments when source and destination address versions mismatched.

The logic now ensures that TCPv6/UDPv6 is selected if either address is IPv6, with IPv4 addresses correctly formatted as IPv4-mapped IPv6 addresses when necessary.

- Migrate from `net.IP` to `netip.Addr` for robust IP handling
- Update version detection to fallback to IPv6 if any address is IPv6
- Ensure strict 4-byte or 16-byte alignment in v1 header output

Migrate from https://github.com/pires/go-proxyproto/pull/115