### PR TITLE
tests: reduce boilerplate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,13 @@ linters:
     - revive
     - unconvert
     - usestdlibvars
+  settings:
+    goconst:
+      # Newer goconst versions default ignore-calls to false, which flags
+      # idiomatic call-argument strings such as t.Fatalf("err: %v", err) and
+      # net.Dial("tcp", addr). Restore the prior default so only genuinely
+      # repeated constant values are reported.
+      ignore-calls: true
 
 run:
   timeout: 5m
@@ -25,3 +32,4 @@ run:
 
 issues:
   max-issues-per-linter: 0
+  max-same-issues: 0

--- a/header.go
+++ b/header.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+// Network names for Unix-domain addresses, matching net.UnixAddr.Net values.
+// The net package exposes no constants for these.
+const (
+	networkUnix     = "unix"
+	networkUnixgram = "unixgram"
+)
+
 var (
 	// SIGV1 is the signature for PROXY protocol v1.
 	SIGV1 = []byte{'\x50', '\x52', '\x4F', '\x58', '\x59'}
@@ -100,9 +107,9 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 			break
 		}
 		switch sourceAddr.Net {
-		case "unix":
+		case networkUnix:
 			h.TransportProtocol = UnixStream
-		case "unixgram":
+		case networkUnixgram:
 			h.TransportProtocol = UnixDatagram
 		}
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -20,6 +20,11 @@ const (
 	testIP6LongAddr         = "1234:5678:9abc:def0:cafe:babe:dead:2bad"
 	testValidPort           = 65533
 	testInvalidPort         = 99999
+
+	// Unix-domain address names reused across address fixtures in tests.
+	testUnixSocketName = "socket"
+	testUnixSrcName    = "src"
+	testUnixDstName    = "dst"
 )
 
 var (
@@ -32,8 +37,8 @@ var (
 	v4UDPAddr net.Addr = &net.UDPAddr{IP: v4ip, Port: testValidPort}
 	v6UDPAddr net.Addr = &net.UDPAddr{IP: v6ip, Port: testValidPort}
 
-	unixStreamAddr   net.Addr = &net.UnixAddr{Net: "unix", Name: "socket"}
-	unixDatagramAddr net.Addr = &net.UnixAddr{Net: "unixgram", Name: "socket"}
+	unixStreamAddr   net.Addr = &net.UnixAddr{Net: networkUnix, Name: testUnixSocketName}
+	unixDatagramAddr net.Addr = &net.UnixAddr{Net: networkUnixgram, Name: testUnixSocketName}
 
 	errReadIntentionallyBroken = errors.New("read is intentionally broken")
 )
@@ -241,21 +246,21 @@ func TestGetters(t *testing.T) {
 				Command:           PROXY,
 				TransportProtocol: UnixStream,
 				SourceAddr: &net.UnixAddr{
-					Net:  "unix",
-					Name: "src",
+					Net:  networkUnix,
+					Name: testUnixSrcName,
 				},
 				DestinationAddr: &net.UnixAddr{
-					Net:  "unix",
-					Name: "dst",
+					Net:  networkUnix,
+					Name: testUnixDstName,
 				},
 			},
 			unixSourceAddr: &net.UnixAddr{
-				Net:  "unix",
-				Name: "src",
+				Net:  networkUnix,
+				Name: testUnixSrcName,
 			},
 			unixDestAddr: &net.UnixAddr{
-				Net:  "unix",
-				Name: "dst",
+				Net:  networkUnix,
+				Name: testUnixDstName,
 			},
 		},
 		{
@@ -265,21 +270,21 @@ func TestGetters(t *testing.T) {
 				Command:           PROXY,
 				TransportProtocol: UnixDatagram,
 				SourceAddr: &net.UnixAddr{
-					Net:  "unix",
-					Name: "src",
+					Net:  networkUnix,
+					Name: testUnixSrcName,
 				},
 				DestinationAddr: &net.UnixAddr{
-					Net:  "unix",
-					Name: "dst",
+					Net:  networkUnix,
+					Name: testUnixDstName,
 				},
 			},
 			unixSourceAddr: &net.UnixAddr{
-				Net:  "unix",
-				Name: "src",
+				Net:  networkUnix,
+				Name: testUnixSrcName,
 			},
 			unixDestAddr: &net.UnixAddr{
-				Net:  "unix",
-				Name: "dst",
+				Net:  networkUnix,
+				Name: testUnixDstName,
 			},
 		},
 		{
@@ -648,48 +653,48 @@ func TestHeaderProxyFromAddrs(t *testing.T) {
 		{
 			name: "UnixStream",
 			sourceAddr: &net.UnixAddr{
-				Net:  "unix",
-				Name: "src",
+				Net:  networkUnix,
+				Name: testUnixSrcName,
 			},
 			destAddr: &net.UnixAddr{
-				Net:  "unix",
-				Name: "dst",
+				Net:  networkUnix,
+				Name: testUnixDstName,
 			},
 			expected: &Header{
 				Version:           2,
 				Command:           PROXY,
 				TransportProtocol: UnixStream,
 				SourceAddr: &net.UnixAddr{
-					Net:  "unix",
-					Name: "src",
+					Net:  networkUnix,
+					Name: testUnixSrcName,
 				},
 				DestinationAddr: &net.UnixAddr{
-					Net:  "unix",
-					Name: "dst",
+					Net:  networkUnix,
+					Name: testUnixDstName,
 				},
 			},
 		},
 		{
 			name: "UnixDatagram",
 			sourceAddr: &net.UnixAddr{
-				Net:  "unixgram",
-				Name: "src",
+				Net:  networkUnixgram,
+				Name: testUnixSrcName,
 			},
 			destAddr: &net.UnixAddr{
-				Net:  "unixgram",
-				Name: "dst",
+				Net:  networkUnixgram,
+				Name: testUnixDstName,
 			},
 			expected: &Header{
 				Version:           2,
 				Command:           PROXY,
 				TransportProtocol: UnixDatagram,
 				SourceAddr: &net.UnixAddr{
-					Net:  "unixgram",
-					Name: "src",
+					Net:  networkUnixgram,
+					Name: testUnixSrcName,
 				},
 				DestinationAddr: &net.UnixAddr{
-					Net:  "unixgram",
-					Name: "dst",
+					Net:  networkUnixgram,
+					Name: testUnixDstName,
 				},
 			},
 		},
@@ -769,7 +774,7 @@ func TestHeaderProxyFromAddrs(t *testing.T) {
 		{
 			name: "UnixAddrTypeMismatch",
 			sourceAddr: &net.UnixAddr{
-				Net: "unix",
+				Net: networkUnix,
 			},
 			destAddr: &net.TCPAddr{
 				IP:   net.ParseIP(testDestinationIPv4Addr),

--- a/policy_test.go
+++ b/policy_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+const (
+	// testWhitelistIP1, testWhitelistIP2 and testWhitelistIP3 are valid sample
+	// IPs reused as the allowed set across whitelist-policy cases.
+	testWhitelistIP1 = "10.0.0.2"
+	testWhitelistIP2 = "10.0.0.3"
+	testWhitelistIP3 = "10.0.0.4"
+	// testWhitelistCIDR is a valid CIDR reused across whitelist-policy cases.
+	testWhitelistCIDR = "10.0.0.0/30"
+	// testMalformedCIDR and testMalformedIP are intentionally invalid inputs
+	// reused across policy error-path cases.
+	testMalformedCIDR = "20/80"
+	testMalformedIP   = "855.222.233.11"
+)
+
 type failingAddr struct{}
 
 func (f failingAddr) Network() string { return "failing" }
@@ -20,8 +34,8 @@ func TestWhitelistPolicyReturnsErrorOnInvalidAddress(t *testing.T) {
 		name   string
 		policy PolicyFunc
 	}{
-		{"strict whitelist policy", MustStrictWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.0/30"})},
-		{"lax whitelist policy", MustLaxWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.0/30"})},
+		{"strict whitelist policy", MustStrictWhiteListPolicy([]string{testWhitelistIP1, testWhitelistIP2, testWhitelistIP3, testWhitelistCIDR})}, //nolint:goconst // test-case label, clearer inline
+		{"lax whitelist policy", MustLaxWhiteListPolicy([]string{testWhitelistIP1, testWhitelistIP2, testWhitelistIP3, testWhitelistCIDR})},       //nolint:goconst // test-case label, clearer inline
 	}
 
 	for _, tc := range cases {
@@ -39,8 +53,8 @@ func TestWhitelistPolicyReturnsErrorOnInvalidIP(t *testing.T) {
 		name   string
 		policy ConnPolicyFunc
 	}{
-		{"conn strict whitelist policy", ConnMustStrictWhiteListPolicy([]string{"10.0.0.3"})},
-		{"conn lax whitelist policy", ConnMustLaxWhiteListPolicy([]string{"10.0.0.3"})},
+		{"conn strict whitelist policy", ConnMustStrictWhiteListPolicy([]string{testWhitelistIP2})},
+		{"conn lax whitelist policy", ConnMustLaxWhiteListPolicy([]string{testWhitelistIP2})},
 	}
 
 	for _, tc := range policies {
@@ -58,7 +72,7 @@ func TestStrictWhitelistPolicyReturnsRejectWhenUpstreamIpAddrNotInWhitelist(t *t
 		name   string
 		policy PolicyFunc
 	}{
-		{"strict whitelist policy", MustStrictWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.0/30"})},
+		{"strict whitelist policy", MustStrictWhiteListPolicy([]string{testWhitelistIP1, testWhitelistIP2, testWhitelistIP3, testWhitelistCIDR})},
 	}
 
 	upstream, err := net.ResolveTCPAddr("tcp", "10.0.0.5:45738")
@@ -85,7 +99,7 @@ func TestLaxWhitelistPolicyReturnsIgnoreWhenUpstreamIpAddrNotInWhitelist(t *test
 		name   string
 		policy PolicyFunc
 	}{
-		{"lax whitelist policy", MustLaxWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.0/30"})},
+		{"lax whitelist policy", MustLaxWhiteListPolicy([]string{testWhitelistIP1, testWhitelistIP2, testWhitelistIP3, testWhitelistCIDR})},
 	}
 
 	upstream, err := net.ResolveTCPAddr("tcp", "10.0.0.5:45738")
@@ -112,8 +126,8 @@ func TestWhitelistPolicyReturnsUseWhenUpstreamIpAddrInWhitelist(t *testing.T) {
 		name   string
 		policy PolicyFunc
 	}{
-		{"strict whitelist policy", MustStrictWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})},
-		{"lax whitelist policy", MustLaxWhiteListPolicy([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})},
+		{"strict whitelist policy", MustStrictWhiteListPolicy([]string{testWhitelistIP1, testWhitelistIP2, testWhitelistIP3})},
+		{"lax whitelist policy", MustLaxWhiteListPolicy([]string{testWhitelistIP1, testWhitelistIP2, testWhitelistIP3})},
 	}
 
 	upstream, err := net.ResolveTCPAddr("tcp", "10.0.0.3:45738")
@@ -169,11 +183,11 @@ func Test_CreateWhitelistPolicyWithInvalidCidrReturnsError(t *testing.T) {
 		fn   func() error
 	}{
 		{"strict whitelist policy", func() error {
-			_, err := StrictWhiteListPolicy([]string{"20/80"})
+			_, err := StrictWhiteListPolicy([]string{testMalformedCIDR})
 			return err
 		}},
 		{"lax whitelist policy", func() error {
-			_, err := LaxWhiteListPolicy([]string{"20/80"})
+			_, err := LaxWhiteListPolicy([]string{testMalformedCIDR})
 			return err
 		}},
 	}
@@ -193,11 +207,11 @@ func Test_CreateWhitelistPolicyWithInvalidIpAddressReturnsError(t *testing.T) {
 		fn   func() error
 	}{
 		{"strict whitelist policy", func() error {
-			_, err := StrictWhiteListPolicy([]string{"855.222.233.11"})
+			_, err := StrictWhiteListPolicy([]string{testMalformedIP})
 			return err
 		}},
 		{"lax whitelist policy", func() error {
-			_, err := LaxWhiteListPolicy([]string{"855.222.233.11"})
+			_, err := LaxWhiteListPolicy([]string{testMalformedIP})
 			return err
 		}},
 	}
@@ -218,7 +232,7 @@ func Test_MustLaxWhiteListPolicyPanicsWithInvalidIpAddress(t *testing.T) {
 		}
 	}()
 
-	MustLaxWhiteListPolicy([]string{"855.222.233.11"})
+	MustLaxWhiteListPolicy([]string{testMalformedIP})
 }
 
 func Test_MustLaxWhiteListPolicyPanicsWithInvalidIpRange(t *testing.T) {
@@ -228,7 +242,7 @@ func Test_MustLaxWhiteListPolicyPanicsWithInvalidIpRange(t *testing.T) {
 		}
 	}()
 
-	MustLaxWhiteListPolicy([]string{"20/80"})
+	MustLaxWhiteListPolicy([]string{testMalformedCIDR})
 }
 
 func Test_MustStrictWhiteListPolicyPanicsWithInvalidIpAddress(t *testing.T) {
@@ -238,7 +252,7 @@ func Test_MustStrictWhiteListPolicyPanicsWithInvalidIpAddress(t *testing.T) {
 		}
 	}()
 
-	MustStrictWhiteListPolicy([]string{"855.222.233.11"})
+	MustStrictWhiteListPolicy([]string{testMalformedIP})
 }
 
 func Test_MustStrictWhiteListPolicyPanicsWithInvalidIpRange(t *testing.T) {
@@ -248,16 +262,16 @@ func Test_MustStrictWhiteListPolicyPanicsWithInvalidIpRange(t *testing.T) {
 		}
 	}()
 
-	MustStrictWhiteListPolicy([]string{"20/80"})
+	MustStrictWhiteListPolicy([]string{testMalformedCIDR})
 }
 
 func TestWhiteListPolicyFuncsReturnPolicies(t *testing.T) {
-	strictPolicy, err := StrictWhiteListPolicy([]string{"10.0.0.3"})
+	strictPolicy, err := StrictWhiteListPolicy([]string{testWhitelistIP2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	laxPolicy, err := LaxWhiteListPolicy([]string{"10.0.0.3"})
+	laxPolicy, err := LaxWhiteListPolicy([]string{testWhitelistIP2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -350,8 +364,8 @@ func TestConnWhitelistPolicies(t *testing.T) {
 		expectedUse    Policy
 		expectedReject Policy
 	}{
-		{"conn strict whitelist policy", ConnMustStrictWhiteListPolicy([]string{"10.0.0.3"}), USE, REJECT},
-		{"conn lax whitelist policy", ConnMustLaxWhiteListPolicy([]string{"10.0.0.3"}), USE, IGNORE},
+		{"conn strict whitelist policy", ConnMustStrictWhiteListPolicy([]string{testWhitelistIP2}), USE, REJECT},
+		{"conn lax whitelist policy", ConnMustLaxWhiteListPolicy([]string{testWhitelistIP2}), USE, IGNORE},
 	}
 
 	allowed, err := net.ResolveTCPAddr("tcp", "10.0.0.3:45738")

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -28,52 +28,145 @@ const testDestinationIPv4Addr string = "20.2.2.2"
 // testLocalhostRandomPort is a localhost random port used in tests.
 const testLocalhostRandomPort string = "127.0.0.1:0"
 
-func TestPassthrough(t *testing.T) {
+// newLocalListener binds a TCP listener on a random localhost port.
+func newLocalListener(t *testing.T) net.Listener {
+	t.Helper()
 	l, err := net.Listen("tcp", testLocalhostRandomPort)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	return l
+}
 
-	pl := &Listener{Listener: l}
+// testTCPv4Header returns the canonical PROXY TCPv4 header shared across tests.
+func testTCPv4Header() *Header {
+	return &Header{
+		Version:           2,
+		Command:           PROXY,
+		TransportProtocol: TCPv4,
+		SourceAddr: &net.TCPAddr{
+			IP:   net.ParseIP(testSourceIPv4Addr),
+			Port: 1000,
+		},
+		DestinationAddr: &net.TCPAddr{
+			IP:   net.ParseIP(testDestinationIPv4Addr),
+			Port: 2000,
+		},
+	}
+}
+
+// closeOnCleanup registers c.Close() as a t.Cleanup, failing the test on error.
+func closeOnCleanup(t *testing.T, name string, c io.Closer) {
+	t.Helper()
+	t.Cleanup(func() {
+		if closeErr := c.Close(); closeErr != nil {
+			t.Errorf("failed to close %s: %v", name, closeErr)
+		}
+	})
+}
+
+// clientConfig parameterizes the standard test client goroutine run by runClient.
+type clientConfig struct {
+	network     string  // dial network, defaults to "tcp"
+	addr        string  // dial target
+	header      *Header // written before the payload when set
+	payload     []byte  // written after the header, defaults to []byte("ping")
+	expectEcho  []byte  // read back and compared when set
+	closeAfter  bool    // close the connection after writing instead of on cleanup
+	connectOnly bool    // only dial, write nothing
+}
+
+// runClient launches the standard client goroutine and returns a channel that
+// is closed on success or receives the first error.
+func runClient(t *testing.T, cfg clientConfig) <-chan error {
+	t.Helper()
+	network := cfg.network
+	if network == "" {
+		network = "tcp"
+	}
+	payload := cfg.payload
+	if payload == nil {
+		payload = []byte("ping")
+	}
 
 	cliResult := make(chan error)
 	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
+		conn, err := net.Dial(network, cfg.addr)
 		if err != nil {
 			cliResult <- err
 			return
 		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
+		if !cfg.closeAfter {
+			closeOnCleanup(t, "connection", conn)
+		}
 
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
+		if cfg.connectOnly {
+			close(cliResult)
 			return
 		}
-		recv := make([]byte, 4)
-		if _, err = conn.Read(recv); err != nil {
-			cliResult <- err
-			return
+
+		if cfg.header != nil {
+			if _, err := cfg.header.WriteTo(conn); err != nil {
+				cliResult <- err
+				return
+			}
 		}
-		if !bytes.Equal(recv, []byte("pong")) {
-			cliResult <- fmt.Errorf("bad: %v", recv)
-			return
+
+		if len(payload) > 0 {
+			if _, err := conn.Write(payload); err != nil {
+				cliResult <- err
+				return
+			}
 		}
+
+		if cfg.expectEcho != nil {
+			recv := make([]byte, len(cfg.expectEcho))
+			if _, err := conn.Read(recv); err != nil {
+				cliResult <- err
+				return
+			}
+			if !bytes.Equal(recv, cfg.expectEcho) {
+				cliResult <- fmt.Errorf("bad: %v", recv)
+				return
+			}
+		}
+
+		if cfg.closeAfter {
+			if err := conn.Close(); err != nil {
+				cliResult <- err
+				return
+			}
+		}
+
 		close(cliResult)
 	}()
+
+	return cliResult
+}
+
+// expectClientOK drains the client result channel and fails on a non-nil error.
+func expectClientOK(t *testing.T, ch <-chan error) {
+	t.Helper()
+	if err := <-ch; err != nil {
+		t.Fatalf("client error: %v", err)
+	}
+}
+
+func TestPassthrough(t *testing.T) {
+	l := newLocalListener(t)
+
+	pl := &Listener{Listener: l}
+
+	cliResult := runClient(t, clientConfig{
+		addr:       pl.Addr().String(),
+		expectEcho: []byte("pong"),
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	_, err = conn.Read(recv)
@@ -87,10 +180,7 @@ func TestPassthrough(t *testing.T) {
 	if _, err := conn.Write([]byte("pong")); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 // TestRequiredWithReadHeaderTimeout will iterate through 3 different timeouts to see
@@ -101,10 +191,7 @@ func TestRequiredWithReadHeaderTimeout(t *testing.T) {
 		t.Run(fmt.Sprint(duration), func(t *testing.T) {
 			start := time.Now()
 
-			l, err := net.Listen("tcp", testLocalhostRandomPort)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
+			l := newLocalListener(t)
 
 			pl := &Listener{
 				Listener:          l,
@@ -114,31 +201,13 @@ func TestRequiredWithReadHeaderTimeout(t *testing.T) {
 				},
 			}
 
-			cliResult := make(chan error)
-			go func() {
-				conn, err := net.Dial("tcp", pl.Addr().String())
-				if err != nil {
-					cliResult <- err
-					return
-				}
-				t.Cleanup(func() {
-					if closeErr := conn.Close(); closeErr != nil {
-						t.Errorf("failed to close connection: %v", closeErr)
-					}
-				})
-
-				close(cliResult)
-			}()
+			cliResult := runClient(t, clientConfig{addr: pl.Addr().String(), connectOnly: true})
 
 			conn, err := pl.Accept()
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
-			t.Cleanup(func() {
-				if closeErr := conn.Close(); closeErr != nil {
-					t.Errorf("failed to close connection: %v", closeErr)
-				}
-			})
+			closeOnCleanup(t, "connection", conn)
 
 			// Read blocks forever if there is no ReadHeaderTimeout and the policy is not REQUIRE
 			recv := make([]byte, 4)
@@ -147,10 +216,7 @@ func TestRequiredWithReadHeaderTimeout(t *testing.T) {
 			if err != nil && !errors.Is(err, ErrNoProxyProtocol) && time.Since(start)-pl.ReadHeaderTimeout > 10*time.Millisecond {
 				t.Fatal("proxy proto should not be found and time should be close to read timeout")
 			}
-			err = <-cliResult
-			if err != nil {
-				t.Fatalf("client error: %v", err)
-			}
+			expectClientOK(t, cliResult)
 		})
 	}
 }
@@ -163,10 +229,7 @@ func TestUseWithReadHeaderTimeout(t *testing.T) {
 		t.Run(fmt.Sprint(duration), func(t *testing.T) {
 			start := time.Now()
 
-			l, err := net.Listen("tcp", testLocalhostRandomPort)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
+			l := newLocalListener(t)
 
 			pl := &Listener{
 				Listener:          l,
@@ -176,31 +239,13 @@ func TestUseWithReadHeaderTimeout(t *testing.T) {
 				},
 			}
 
-			cliResult := make(chan error)
-			go func() {
-				conn, err := net.Dial("tcp", pl.Addr().String())
-				if err != nil {
-					cliResult <- err
-					return
-				}
-				t.Cleanup(func() {
-					if closeErr := conn.Close(); closeErr != nil {
-						t.Errorf("failed to close connection: %v", closeErr)
-					}
-				})
-
-				close(cliResult)
-			}()
+			cliResult := runClient(t, clientConfig{addr: pl.Addr().String(), connectOnly: true})
 
 			conn, err := pl.Accept()
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
-			t.Cleanup(func() {
-				if closeErr := conn.Close(); closeErr != nil {
-					t.Errorf("failed to close connection: %v", closeErr)
-				}
-			})
+			closeOnCleanup(t, "connection", conn)
 
 			// 2 times the ReadHeaderTimeout because the first timeout
 			// should occur (the one set on the listener) and allow for the second to follow up
@@ -215,26 +260,15 @@ func TestUseWithReadHeaderTimeout(t *testing.T) {
 			if err != nil && !errors.Is(err, ErrNoProxyProtocol) && (time.Since(start)-(pl.ReadHeaderTimeout*2)) > 10*time.Millisecond {
 				t.Fatal("proxy proto should not be found and time should be close to read timeout")
 			}
-			err = <-cliResult
-			if err != nil {
-				t.Fatalf("client error: %v", err)
-			}
+			expectClientOK(t, cliResult)
 		})
 	}
 }
 
 func TestNewConnSetReadHeaderTimeoutOption(t *testing.T) {
 	conn, peer := net.Pipe()
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
-	t.Cleanup(func() {
-		if closeErr := peer.Close(); closeErr != nil {
-			t.Errorf("failed to close peer connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
+	closeOnCleanup(t, "peer connection", peer)
 
 	// Ensure SetReadHeaderTimeout sets the connection-specific timeout.
 	timeout := 150 * time.Millisecond
@@ -246,16 +280,8 @@ func TestNewConnSetReadHeaderTimeoutOption(t *testing.T) {
 
 func TestNewConnSetReadHeaderTimeoutIgnoresNegative(t *testing.T) {
 	conn, peer := net.Pipe()
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
-	t.Cleanup(func() {
-		if closeErr := peer.Close(); closeErr != nil {
-			t.Errorf("failed to close peer connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
+	closeOnCleanup(t, "peer connection", peer)
 
 	// Negative values should be ignored, leaving the timeout unset.
 	proxyConn := NewConn(conn, SetReadHeaderTimeout(-1))
@@ -316,10 +342,7 @@ func TestWithBufferSizeZeroOrNegative(t *testing.T) {
 }
 
 func TestListenerReadBufferSizeApplied(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 	t.Cleanup(func() { _ = l.Close() })
 
 	pl := &Listener{Listener: l, ReadBufferSize: 4096}
@@ -347,10 +370,7 @@ func TestListenerReadBufferSizeApplied(t *testing.T) {
 }
 
 func TestListenerReadBufferSizeZeroUsesDefault(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 	t.Cleanup(func() { _ = l.Close() })
 
 	pl := &Listener{Listener: l, ReadBufferSize: 0}
@@ -381,10 +401,7 @@ func TestReadHeaderTimeoutRespectsEarlierDeadline(t *testing.T) {
 		tolerance     = 100 * time.Millisecond
 	)
 
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{
 		Listener:          l,
@@ -410,21 +427,13 @@ func TestReadHeaderTimeoutRespectsEarlierDeadline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	result := <-dialResultCh
 	if result.err != nil {
 		t.Fatalf("client error: %v", result.err)
 	}
-	t.Cleanup(func() {
-		if closeErr := result.conn.Close(); closeErr != nil {
-			t.Errorf("failed to close client connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "client connection", result.conn)
 
 	// Set a shorter user deadline than the readHeaderTimeout and do not send data.
 	if err := conn.SetReadDeadline(time.Now().Add(userTimeout)); err != nil {
@@ -448,16 +457,8 @@ func TestReadHeaderTimeoutRespectsEarlierDeadline(t *testing.T) {
 
 func TestDeadlineSettersAfterHeaderProcessed(t *testing.T) {
 	conn, peer := net.Pipe()
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
-	t.Cleanup(func() {
-		if closeErr := peer.Close(); closeErr != nil {
-			t.Errorf("failed to close peer connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
+	closeOnCleanup(t, "peer connection", peer)
 
 	proxyConn := NewConn(conn)
 
@@ -488,29 +489,14 @@ func TestDeadlineSettersAfterHeaderProcessed(t *testing.T) {
 func TestReadHeaderTimeoutIsReset(t *testing.T) {
 	const timeout = time.Millisecond * 250
 
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{
 		Listener:          l,
 		ReadHeaderTimeout: timeout,
 	}
 
-	header := &Header{
-		Version:           2,
-		Command:           PROXY,
-		TransportProtocol: TCPv4,
-		SourceAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testSourceIPv4Addr),
-			Port: 1000,
-		},
-		DestinationAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testDestinationIPv4Addr),
-			Port: 2000,
-		},
-	}
+	header := testTCPv4Header()
 
 	cliResult := make(chan error)
 	go func() {
@@ -519,11 +505,7 @@ func TestReadHeaderTimeoutIsReset(t *testing.T) {
 			cliResult <- err
 			return
 		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
+		closeOnCleanup(t, "connection", conn)
 
 		// Write out the header!
 		if _, err := header.WriteTo(conn); err != nil {
@@ -554,11 +536,7 @@ func TestReadHeaderTimeoutIsReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	// Set our deadlines higher than our ReadHeaderTimeout
 	if err := conn.SetReadDeadline(time.Now().Add(timeout * 3)); err != nil {
@@ -593,10 +571,7 @@ func TestReadHeaderTimeoutIsReset(t *testing.T) {
 	if !h.EqualsTo(header) {
 		t.Errorf("bad: %v", h)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 // TestReadHeaderTimeoutIsEmpty ensures the default is set if it is empty.
@@ -606,28 +581,13 @@ func TestReadHeaderTimeoutIsReset(t *testing.T) {
 func TestReadHeaderTimeoutIsEmpty(t *testing.T) {
 	DefaultReadHeaderTimeout = 200 * time.Millisecond
 
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{
 		Listener: l,
 	}
 
-	header := &Header{
-		Version:           2,
-		Command:           PROXY,
-		TransportProtocol: TCPv4,
-		SourceAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testSourceIPv4Addr),
-			Port: 1000,
-		},
-		DestinationAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testDestinationIPv4Addr),
-			Port: 2000,
-		},
-	}
+	header := testTCPv4Header()
 
 	cliResult := make(chan error)
 	go func() {
@@ -636,11 +596,7 @@ func TestReadHeaderTimeoutIsEmpty(t *testing.T) {
 			cliResult <- err
 			return
 		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
+		closeOnCleanup(t, "connection", conn)
 
 		// Sleep here longer than the configured timeout.
 		time.Sleep(250 * time.Millisecond)
@@ -663,11 +619,7 @@ func TestReadHeaderTimeoutIsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != nil {
@@ -682,39 +634,21 @@ func TestReadHeaderTimeoutIsEmpty(t *testing.T) {
 	if addr.Port == 1000 {
 		t.Fatalf("bad: %v", addr)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 // TestReadHeaderTimeoutIsNegative does the same as above except
 // with a negative timeout. Therefore, we expect the right ProxyHeader
 // to be returned.
 func TestReadHeaderTimeoutIsNegative(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{
 		Listener:          l,
 		ReadHeaderTimeout: -1,
 	}
 
-	header := &Header{
-		Version:           2,
-		Command:           PROXY,
-		TransportProtocol: TCPv4,
-		SourceAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testSourceIPv4Addr),
-			Port: 1000,
-		},
-		DestinationAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testDestinationIPv4Addr),
-			Port: 2000,
-		},
-	}
+	header := testTCPv4Header()
 
 	cliResult := make(chan error)
 	go func() {
@@ -723,11 +657,7 @@ func TestReadHeaderTimeoutIsNegative(t *testing.T) {
 			cliResult <- err
 			return
 		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
+		closeOnCleanup(t, "connection", conn)
 
 		// Sleep here longer than the configured timeout.
 		time.Sleep(250 * time.Millisecond)
@@ -750,11 +680,7 @@ func TestReadHeaderTimeoutIsNegative(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != nil {
@@ -776,72 +702,23 @@ func TestReadHeaderTimeoutIsNegative(t *testing.T) {
 }
 
 func TestParse_ipv4(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{Listener: l}
 
-	header := &Header{
-		Version:           2,
-		Command:           PROXY,
-		TransportProtocol: TCPv4,
-		SourceAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testSourceIPv4Addr),
-			Port: 1000,
-		},
-		DestinationAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testDestinationIPv4Addr),
-			Port: 2000,
-		},
-	}
+	header := testTCPv4Header()
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		// Write out the header!
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		recv := make([]byte, 4)
-		if _, err = conn.Read(recv); err != nil {
-			cliResult <- err
-			return
-		}
-		if !bytes.Equal(recv, []byte("pong")) {
-			cliResult <- fmt.Errorf("bad: %v", recv)
-			return
-		}
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{
+		addr:       pl.Addr().String(),
+		header:     header,
+		expectEcho: []byte("pong"),
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != nil {
@@ -868,10 +745,7 @@ func TestParse_ipv4(t *testing.T) {
 	if !h.EqualsTo(header) {
 		t.Errorf("bad: %v", h)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestParse_unixStream(t *testing.T) {
@@ -881,11 +755,7 @@ func TestParse_unixStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := l.Close(); closeErr != nil {
-			t.Errorf("failed to close listener: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "listener", l)
 
 	pl := &Listener{Listener: l}
 
@@ -903,52 +773,18 @@ func TestParse_unixStream(t *testing.T) {
 		},
 	}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("unix", socketPath)
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		defer func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		}()
-
-		// Write out the header!
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		recv := make([]byte, 4)
-		if _, err = conn.Read(recv); err != nil {
-			cliResult <- err
-			return
-		}
-		if !bytes.Equal(recv, []byte("pong")) {
-			cliResult <- fmt.Errorf("bad: %v", recv)
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{
+		network:    "unix",
+		addr:       socketPath,
+		header:     header,
+		expectEcho: []byte("pong"),
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != nil {
@@ -972,24 +808,13 @@ func TestParse_unixStream(t *testing.T) {
 		t.Errorf("bad: %v", h)
 	}
 
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestParse_unixDatagram(t *testing.T) {
 	server, client := net.Pipe()
-	t.Cleanup(func() {
-		if closeErr := client.Close(); closeErr != nil {
-			t.Errorf("failed to close client: %v", closeErr)
-		}
-	})
-	t.Cleanup(func() {
-		if closeErr := server.Close(); closeErr != nil {
-			t.Errorf("failed to close server: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "client", client)
+	closeOnCleanup(t, "server", server)
 
 	header := &Header{
 		Version:           2,
@@ -1046,10 +871,7 @@ func TestParse_unixDatagram(t *testing.T) {
 }
 
 func TestParse_ipv6(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{Listener: l}
 
@@ -1067,51 +889,17 @@ func TestParse_ipv6(t *testing.T) {
 		},
 	}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		// Write out the header!
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		recv := make([]byte, 4)
-		if _, err = conn.Read(recv); err != nil {
-			cliResult <- err
-			return
-		}
-		if !bytes.Equal(recv, []byte("pong")) {
-			cliResult <- fmt.Errorf("bad: %v", recv)
-			return
-		}
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{
+		addr:       pl.Addr().String(),
+		header:     header,
+		expectEcho: []byte("pong"),
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != nil {
@@ -1138,37 +926,18 @@ func TestParse_ipv6(t *testing.T) {
 	if !h.EqualsTo(header) {
 		t.Errorf("bad: %v", h)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestAcceptReturnsErrorWhenPolicyFuncErrors(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	expectedErr := fmt.Errorf("failure")
 	policyFunc := func(_ net.Addr) (Policy, error) { return USE, expectedErr }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String(), connectOnly: true})
 
 	conn, err := pl.Accept()
 	if err != expectedErr {
@@ -1178,38 +947,18 @@ func TestAcceptReturnsErrorWhenPolicyFuncErrors(t *testing.T) {
 	if conn != nil {
 		t.Fatalf("Expected no connection, got %v", conn)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestPanicIfPolicyAndConnPolicySet(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	connPolicyFunc := func(_ ConnPolicyOptions) (Policy, error) { return USE, nil }
 	policyFunc := func(_ net.Addr) (Policy, error) { return USE, nil }
 
 	pl := &Listener{Listener: l, ConnPolicy: connPolicyFunc, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		close(cliResult)
-	}()
+	runClient(t, clientConfig{addr: pl.Addr().String(), connectOnly: true})
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("accept did panic as expected with error, %v", r)
@@ -1227,31 +976,14 @@ func TestPanicIfPolicyAndConnPolicySet(t *testing.T) {
 }
 
 func TestAcceptReturnsErrorWhenConnPolicyFuncErrors(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	expectedErr := fmt.Errorf("failure")
 	connPolicyFunc := func(_ ConnPolicyOptions) (Policy, error) { return USE, expectedErr }
 
 	pl := &Listener{Listener: l, ConnPolicy: connPolicyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String(), connectOnly: true})
 
 	conn, err := pl.Accept()
 	if err != expectedErr {
@@ -1261,195 +993,75 @@ func TestAcceptReturnsErrorWhenConnPolicyFuncErrors(t *testing.T) {
 	if conn != nil {
 		t.Fatalf("Expected no connection, got %v", conn)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestReadingIsRefusedWhenProxyHeaderRequiredButMissing(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return REQUIRE, nil }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String()})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != ErrNoProxyProtocol {
 		t.Fatalf("Expected error %v, received %v", ErrNoProxyProtocol, err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestReadingIsRefusedWhenProxyHeaderPresentButNotAllowed(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return REJECT, nil }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-		header := &Header{
-			Version:           2,
-			Command:           PROXY,
-			TransportProtocol: TCPv4,
-			SourceAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testSourceIPv4Addr),
-				Port: 1000,
-			},
-			DestinationAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testDestinationIPv4Addr),
-				Port: 2000,
-			},
-		}
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{
+		addr:    pl.Addr().String(),
+		header:  testTCPv4Header(),
+		payload: []byte{},
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != ErrSuperfluousProxyHeader {
 		t.Fatalf("Expected error %v, received %v", ErrSuperfluousProxyHeader, err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestIgnorePolicyIgnoresIpFromProxyHeader(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return IGNORE, nil }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		// Write out the header!
-		header := &Header{
-			Version:           2,
-			Command:           PROXY,
-			TransportProtocol: TCPv4,
-			SourceAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testSourceIPv4Addr),
-				Port: 1000,
-			},
-			DestinationAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testDestinationIPv4Addr),
-				Port: 2000,
-			},
-		}
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		recv := make([]byte, 4)
-		if _, err = conn.Read(recv); err != nil {
-			cliResult <- err
-			return
-		}
-		if !bytes.Equal(recv, []byte("pong")) {
-			cliResult <- fmt.Errorf("bad: %v", recv)
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{
+		addr:       pl.Addr().String(),
+		header:     testTCPv4Header(),
+		expectEcho: []byte("pong"),
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != nil {
@@ -1468,10 +1080,7 @@ func TestIgnorePolicyIgnoresIpFromProxyHeader(t *testing.T) {
 	if addr.IP.String() != "127.0.0.1" {
 		t.Fatalf("bad: %v", addr)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func Test_AllOptionsAreRecognized(t *testing.T) {
@@ -1486,11 +1095,7 @@ func Test_AllOptionsAreRecognized(t *testing.T) {
 	}
 
 	server, client := net.Pipe()
-	t.Cleanup(func() {
-		if closeErr := client.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", client)
 
 	c := NewConn(server, opt1, opt2)
 	if !recognizedOpt1 {
@@ -1501,122 +1106,57 @@ func Test_AllOptionsAreRecognized(t *testing.T) {
 		t.Error("Expected option 2 recognized")
 	}
 
-	t.Cleanup(func() {
-		if closeErr := c.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", c)
 }
 
 func TestReadingIsRefusedOnErrorWhenRemoteAddrRequestedFirst(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return REQUIRE, nil }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String()})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	_ = conn.RemoteAddr()
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != ErrNoProxyProtocol {
 		t.Fatalf("Expected error %v, received %v", ErrNoProxyProtocol, err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestReadingIsRefusedOnErrorWhenLocalAddrRequestedFirst(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return REQUIRE, nil }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String()})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	_ = conn.LocalAddr()
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != ErrNoProxyProtocol {
 		t.Fatalf("Expected error %v, received %v", ErrNoProxyProtocol, err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestSkipProxyProtocolPolicy(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	connPolicyFunc := func(_ ConnPolicyOptions) (Policy, error) { return SKIP, nil }
 
@@ -1625,37 +1165,14 @@ func TestSkipProxyProtocolPolicy(t *testing.T) {
 		ConnPolicy: connPolicyFunc,
 	}
 
-	cliResult := make(chan error)
 	ping := []byte("ping")
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		if _, err := conn.Write(ping); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String(), payload: ping})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	_, ok := conn.(*net.TCPConn)
 	if !ok {
@@ -1671,17 +1188,11 @@ func TestSkipProxyProtocolPolicy(t *testing.T) {
 		t.Fatalf("Unexpected %s data while expected %s", recv, ping)
 	}
 
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestSkipProxyProtocolConnPolicy(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return SKIP, nil }
 
@@ -1690,37 +1201,14 @@ func TestSkipProxyProtocolConnPolicy(t *testing.T) {
 		Policy:   policyFunc,
 	}
 
-	cliResult := make(chan error)
 	ping := []byte("ping")
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		if _, err := conn.Write(ping); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String(), payload: ping})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	_, ok := conn.(*net.TCPConn)
 	if !ok {
@@ -1736,17 +1224,11 @@ func TestSkipProxyProtocolConnPolicy(t *testing.T) {
 		t.Fatalf("Unexpected %s data while expected %s", recv, ping)
 	}
 
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func TestLocalCommandUsesUnderlyingAddrs(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{Listener: l}
 
@@ -1756,42 +1238,18 @@ func TestLocalCommandUsesUnderlyingAddrs(t *testing.T) {
 		TransportProtocol: UNSPEC,
 	}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-
-		// Write a LOCAL header with no address information.
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		// Close client side to avoid leaving the connection open.
-		if err := conn.Close(); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	// closeAfter closes the client side to avoid leaving the connection open.
+	cliResult := runClient(t, clientConfig{
+		addr:       pl.Addr().String(),
+		header:     header,
+		closeAfter: true,
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	proxyConn := conn.(*Conn)
 	// LOCAL should make LocalAddr/RemoteAddr fall back to underlying addresses.
@@ -1802,52 +1260,23 @@ func TestLocalCommandUsesUnderlyingAddrs(t *testing.T) {
 		t.Fatalf("RemoteAddr should use underlying address for LOCAL command")
 	}
 
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func Test_ConnectionCasts(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	policyFunc := func(_ net.Addr) (Policy, error) { return REQUIRE, nil }
 
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		if _, err := conn.Write([]byte("ping")); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{addr: pl.Addr().String()})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	proxyprotoConn := conn.(*Conn)
 	_, ok := proxyprotoConn.TCPConn()
@@ -1866,74 +1295,32 @@ func Test_ConnectionCasts(t *testing.T) {
 	if !ok {
 		t.Fatal("err: should be a tcp connection")
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func Test_ConnectionErrorsWhenHeaderValidationFails(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	validationError := fmt.Errorf("failed to validate")
 	pl := &Listener{Listener: l, ValidateHeader: func(*Header) error { return validationError }}
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
-
-		// Write out the header!
-		header := &Header{
-			Version:           2,
-			Command:           PROXY,
-			TransportProtocol: TCPv4,
-			SourceAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testSourceIPv4Addr),
-				Port: 1000,
-			},
-			DestinationAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testDestinationIPv4Addr),
-				Port: 2000,
-			},
-		}
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	cliResult := runClient(t, clientConfig{
+		addr:    pl.Addr().String(),
+		header:  testTCPv4Header(),
+		payload: []byte{},
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 4)
 	if _, err = conn.Read(recv); err != validationError {
 		t.Fatalf("expected validation error, got %v", err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func Test_ConnectionHandlesInvalidUpstreamError(t *testing.T) {
@@ -2076,10 +1463,7 @@ func NewTestTLSServer(l net.Listener) *TestTLSServer {
 }
 
 func Test_TLSServer(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	s := NewTestTLSServer(l)
 	s.Listener = &Listener{
@@ -2101,27 +1485,10 @@ func Test_TLSServer(t *testing.T) {
 			cliResult <- err
 			return
 		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
+		closeOnCleanup(t, "connection", conn)
 
 		// Write out the header!
-		header := &Header{
-			Version:           2,
-			Command:           PROXY,
-			TransportProtocol: TCPv4,
-			SourceAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testSourceIPv4Addr),
-				Port: 1000,
-			},
-			DestinationAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testDestinationIPv4Addr),
-				Port: 2000,
-			},
-		}
-		if _, err := header.WriteTo(conn); err != nil {
+		if _, err := testTCPv4Header().WriteTo(conn); err != nil {
 			cliResult <- err
 			return
 		}
@@ -2138,11 +1505,7 @@ func Test_TLSServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 1024)
 	n, err := conn.Read(recv)
@@ -2152,17 +1515,11 @@ func Test_TLSServer(t *testing.T) {
 	if string(recv[:n]) != "test" {
 		t.Fatalf("expected \"test\", got \"%s\" %v", recv[:n], recv[:n])
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 func Test_MisconfiguredTLSServerRespondsWithUnderlyingError(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	s := NewTestTLSServer(l)
 	s.Listener = &Listener{
@@ -2196,27 +1553,10 @@ func Test_MisconfiguredTLSServerRespondsWithUnderlyingError(t *testing.T) {
 			cliResult <- err
 			return
 		}
-		t.Cleanup(func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				t.Errorf("failed to close connection: %v", closeErr)
-			}
-		})
+		closeOnCleanup(t, "connection", conn)
 
 		// Write out the header!
-		header := &Header{
-			Version:           2,
-			Command:           PROXY,
-			TransportProtocol: TCPv4,
-			SourceAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testSourceIPv4Addr),
-				Port: 1000,
-			},
-			DestinationAddr: &net.TCPAddr{
-				IP:   net.ParseIP(testDestinationIPv4Addr),
-				Port: 2000,
-			},
-		}
-		if _, err := header.WriteTo(conn); err != nil {
+		if _, err := testTCPv4Header().WriteTo(conn); err != nil {
 			cliResult <- err
 			return
 		}
@@ -2233,20 +1573,13 @@ func Test_MisconfiguredTLSServerRespondsWithUnderlyingError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	recv := make([]byte, 1024)
 	if _, err = conn.Read(recv); err.Error() != "tls: first record does not look like a TLS handshake" {
 		t.Fatalf("expected tls handshake error, got %s", err)
 	}
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 type testConn struct {
@@ -2407,65 +1740,25 @@ func TestReadFromFallbackCopiesToConn(t *testing.T) {
 }
 
 func TestWriteToDrainsBufferedData(t *testing.T) {
-	l, err := net.Listen("tcp", testLocalhostRandomPort)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := newLocalListener(t)
 
 	pl := &Listener{Listener: l}
 
-	header := &Header{
-		Version:           2,
-		Command:           PROXY,
-		TransportProtocol: TCPv4,
-		SourceAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testSourceIPv4Addr),
-			Port: 1000,
-		},
-		DestinationAddr: &net.TCPAddr{
-			IP:   net.ParseIP(testDestinationIPv4Addr),
-			Port: 2000,
-		},
-	}
-
 	payload := []byte("ping")
 
-	cliResult := make(chan error)
-	go func() {
-		conn, err := net.Dial("tcp", pl.Addr().String())
-		if err != nil {
-			cliResult <- err
-			return
-		}
-
-		// Write the header followed by payload to populate the reader buffer.
-		if _, err := header.WriteTo(conn); err != nil {
-			cliResult <- err
-			return
-		}
-		if _, err := conn.Write(payload); err != nil {
-			cliResult <- err
-			return
-		}
-
-		// Close the client so WriteTo's io.Copy completes.
-		if err := conn.Close(); err != nil {
-			cliResult <- err
-			return
-		}
-
-		close(cliResult)
-	}()
+	// closeAfter closes the client so WriteTo's io.Copy completes.
+	cliResult := runClient(t, clientConfig{
+		addr:       pl.Addr().String(),
+		header:     testTCPv4Header(),
+		payload:    payload,
+		closeAfter: true,
+	})
 
 	conn, err := pl.Accept()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("failed to close connection: %v", closeErr)
-		}
-	})
+	closeOnCleanup(t, "connection", conn)
 
 	var out bytes.Buffer
 	if _, err := conn.(*Conn).WriteTo(&out); err != nil {
@@ -2475,10 +1768,7 @@ func TestWriteToDrainsBufferedData(t *testing.T) {
 		t.Fatalf("unexpected WriteTo output: %q", out.String())
 	}
 
-	err = <-cliResult
-	if err != nil {
-		t.Fatalf("client error: %v", err)
-	}
+	expectClientOK(t, cliResult)
 }
 
 // chunkedConn wraps a net.Conn and limits reads to simulate TCP chunking.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -759,7 +759,7 @@ func TestParse_ipv4(t *testing.T) {
 func TestParse_unixStream(t *testing.T) {
 	socketDir := t.TempDir()
 	socketPath := filepath.Join(socketDir, "proxy.sock")
-	l, err := net.Listen("unix", socketPath)
+	l, err := net.Listen(networkUnix, socketPath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -772,17 +772,17 @@ func TestParse_unixStream(t *testing.T) {
 		Command:           PROXY,
 		TransportProtocol: UnixStream,
 		SourceAddr: &net.UnixAddr{
-			Net:  "unix",
+			Net:  networkUnix,
 			Name: "source.sock",
 		},
 		DestinationAddr: &net.UnixAddr{
-			Net:  "unix",
+			Net:  networkUnix,
 			Name: "dest.sock",
 		},
 	}
 
 	cliResult := runClient(t, clientConfig{
-		network:    "unix",
+		network:    networkUnix,
 		addr:       socketPath,
 		header:     header,
 		expectEcho: []byte("pong"),
@@ -830,11 +830,11 @@ func TestParse_unixDatagram(t *testing.T) {
 		Command:           PROXY,
 		TransportProtocol: UnixDatagram,
 		SourceAddr: &net.UnixAddr{
-			Net:  "unixgram",
+			Net:  networkUnixgram,
 			Name: "source.sock",
 		},
 		DestinationAddr: &net.UnixAddr{
-			Net:  "unixgram",
+			Net:  networkUnixgram,
 			Name: "dest.sock",
 		},
 	}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -70,7 +70,8 @@ type clientConfig struct {
 	network     string  // dial network, defaults to "tcp"
 	addr        string  // dial target
 	header      *Header // written before the payload when set
-	payload     []byte  // written after the header; nil defaults to "ping", []byte{} writes nothing
+	payload     []byte  // written after the header; defaults to "ping" when nil, unless headerOnly is set
+	headerOnly  bool    // write only the header (if any) and no payload
 	expectEcho  []byte  // read back and compared when set
 	closeAfter  bool    // close the connection after writing instead of on cleanup
 	connectOnly bool    // only dial, write nothing
@@ -80,22 +81,29 @@ type clientConfig struct {
 // is closed on success or receives the first error.
 func runClient(t *testing.T, cfg clientConfig) <-chan error {
 	t.Helper()
+	if cfg.connectOnly && cfg.closeAfter {
+		t.Fatalf("runClient: connectOnly and closeAfter are mutually exclusive")
+	}
 	network := cfg.network
 	if network == "" {
 		network = "tcp"
 	}
 	payload := cfg.payload
-	if payload == nil {
+	if payload == nil && !cfg.headerOnly {
 		payload = []byte("ping")
 	}
 
-	cliResult := make(chan error)
+	// Buffered so the goroutine never blocks reporting an error if the test
+	// has already failed and stopped reading the channel.
+	cliResult := make(chan error, 1)
 	go func() {
 		conn, err := net.Dial(network, cfg.addr)
 		if err != nil {
 			cliResult <- err
 			return
 		}
+		// connectOnly never reaches the closeAfter branch below, so it always
+		// relies on cleanup; the guard above keeps the two options exclusive.
 		if !cfg.closeAfter {
 			closeOnCleanup(t, "connection", conn)
 		}
@@ -1027,9 +1035,9 @@ func TestReadingIsRefusedWhenProxyHeaderPresentButNotAllowed(t *testing.T) {
 	pl := &Listener{Listener: l, Policy: policyFunc}
 
 	cliResult := runClient(t, clientConfig{
-		addr:    pl.Addr().String(),
-		header:  testTCPv4Header(),
-		payload: []byte{},
+		addr:       pl.Addr().String(),
+		header:     testTCPv4Header(),
+		headerOnly: true,
 	})
 
 	conn, err := pl.Accept()
@@ -1306,9 +1314,9 @@ func Test_ConnectionErrorsWhenHeaderValidationFails(t *testing.T) {
 	pl := &Listener{Listener: l, ValidateHeader: func(*Header) error { return validationError }}
 
 	cliResult := runClient(t, clientConfig{
-		addr:    pl.Addr().String(),
-		header:  testTCPv4Header(),
-		payload: []byte{},
+		addr:       pl.Addr().String(),
+		header:     testTCPv4Header(),
+		headerOnly: true,
 	})
 
 	conn, err := pl.Accept()

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -70,7 +70,7 @@ type clientConfig struct {
 	network     string  // dial network, defaults to "tcp"
 	addr        string  // dial target
 	header      *Header // written before the payload when set
-	payload     []byte  // written after the header, defaults to []byte("ping")
+	payload     []byte  // written after the header; nil defaults to "ping", []byte{} writes nothing
 	expectEcho  []byte  // read back and compared when set
 	closeAfter  bool    // close the connection after writing instead of on cleanup
 	connectOnly bool    // only dial, write nothing
@@ -778,6 +778,7 @@ func TestParse_unixStream(t *testing.T) {
 		addr:       socketPath,
 		header:     header,
 		expectEcho: []byte("pong"),
+		closeAfter: true,
 	})
 
 	conn, err := pl.Accept()

--- a/v1.go
+++ b/v1.go
@@ -13,6 +13,12 @@ import (
 const (
 	crlf      = "\r\n"
 	separator = " "
+
+	// v1ProtoTCP4 and v1ProtoTCP6 are the PROXY protocol v1 transport-protocol
+	// tokens for TCP over IPv4 and IPv6 respectively (net has no constants for
+	// these textual identifiers).
+	v1ProtoTCP4 = "TCP4"
+	v1ProtoTCP6 = "TCP6"
 )
 
 func initVersion1() *Header {
@@ -106,9 +112,9 @@ func parseVersion1(reader *bufio.Reader) (*Header, error) {
 	// Read address family and protocol
 	var transportProtocol AddressFamilyAndProtocol
 	switch tokens[1] {
-	case "TCP4":
+	case v1ProtoTCP4:
 		transportProtocol = TCPv4
-	case "TCP6":
+	case v1ProtoTCP6:
 		transportProtocol = TCPv6
 	case "UNKNOWN":
 		transportProtocol = UNSPEC // doesn't exist in v1 but fits UNKNOWN
@@ -170,9 +176,9 @@ func (header *Header) formatVersion1() ([]byte, error) {
 	var proto string
 	switch header.TransportProtocol {
 	case TCPv4:
-		proto = "TCP4"
+		proto = v1ProtoTCP4
 	case TCPv6:
-		proto = "TCP6"
+		proto = v1ProtoTCP6
 	default:
 		// Unknown connection (short form)
 		return []byte("PROXY UNKNOWN" + crlf), nil

--- a/v2.go
+++ b/v2.go
@@ -148,9 +148,9 @@ func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
 				return nil, fmt.Errorf("%w: %w", ErrInvalidAddress, err)
 			}
 
-			network := "unix"
+			network := networkUnix
 			if header.TransportProtocol.IsDatagram() {
-				network = "unixgram"
+				network = networkUnixgram
 			}
 
 			header.SourceAddr = &net.UnixAddr{

--- a/v2_test.go
+++ b/v2_test.go
@@ -35,7 +35,7 @@ var (
 		return a
 	}()
 
-	unixBytes = pad([]byte("socket"), 108)
+	unixBytes = pad([]byte(testUnixSocketName), 108)
 
 	// Tests don't care if source and destination addresses and ports are the same.
 	addressesIPv4 = append(v4ip.To4(), v4ip.To4()...)
@@ -200,7 +200,7 @@ var validParseAndWriteV2Tests = []struct {
 		},
 	},
 	{
-		desc:   "proxy TCPv4",
+		desc:   "proxy TCPv4", //nolint:goconst // test-case label, clearer inline
 		reader: newBufioReader(append(append(SIGV2, byte(PROXY), byte(TCPv4)), fixtureIPv4V2...)),
 		expectedHeader: &Header{
 			Version:           2,
@@ -211,7 +211,7 @@ var validParseAndWriteV2Tests = []struct {
 		},
 	},
 	{
-		desc:   "proxy TCPv6",
+		desc:   "proxy TCPv6", //nolint:goconst // test-case label, clearer inline
 		reader: newBufioReader(append(append(SIGV2, byte(PROXY), byte(TCPv6)), fixtureIPv6V2...)),
 		expectedHeader: &Header{
 			Version:           2,
@@ -258,7 +258,7 @@ var validParseAndWriteV2Tests = []struct {
 		},
 	},
 	{
-		desc:   "proxy UDPv4",
+		desc:   "proxy UDPv4", //nolint:goconst // test-case label, clearer inline
 		reader: newBufioReader(append(append(SIGV2, byte(PROXY), byte(UDPv4)), fixtureIPv4V2...)),
 		expectedHeader: &Header{
 			Version:           2,
@@ -269,7 +269,7 @@ var validParseAndWriteV2Tests = []struct {
 		},
 	},
 	{
-		desc:   "proxy UDPv6",
+		desc:   "proxy UDPv6", //nolint:goconst // test-case label, clearer inline
 		reader: newBufioReader(append(append(SIGV2, byte(PROXY), byte(UDPv6)), fixtureIPv6V2...)),
 		expectedHeader: &Header{
 			Version:           2,
@@ -608,7 +608,7 @@ func Test_parseUnixName(t *testing.T) {
 func Test_formatUnixName(t *testing.T) {
 	maxLen := int(lengthUnix) / 2
 	longName := strings.Repeat("a", maxLen+5)
-	shortName := "socket"
+	shortName := testUnixSocketName
 
 	longFormatted := formatUnixName(longName)
 	if len(longFormatted) != maxLen {


### PR DESCRIPTION
Also addresses stricter `goconst` on newer `golangci-lint`.

Fixes #72 
Closes #170 