### PR TITLE
Improve IP family handling

### DIFF
--- a/header.go
+++ b/header.go
@@ -85,21 +85,25 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 	}
 	switch sourceAddr := sourceAddr.(type) {
 	case *net.TCPAddr:
-		if _, ok := destAddr.(*net.TCPAddr); !ok {
+		destAddr, ok := destAddr.(*net.TCPAddr)
+		if !ok {
 			break
 		}
-		if len(sourceAddr.IP.To4()) == net.IPv4len {
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = TCPv4
-		} else if len(sourceAddr.IP) == net.IPv6len {
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
 			h.TransportProtocol = TCPv6
 		}
 	case *net.UDPAddr:
-		if _, ok := destAddr.(*net.UDPAddr); !ok {
+		destAddr, ok := destAddr.(*net.UDPAddr)
+		if !ok {
 			break
 		}
-		if len(sourceAddr.IP.To4()) == net.IPv4len {
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = UDPv4
-		} else if len(sourceAddr.IP) == net.IPv6len {
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
 			h.TransportProtocol = UDPv6
 		}
 	case *net.UnixAddr:

--- a/header.go
+++ b/header.go
@@ -114,9 +114,15 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 			h.TransportProtocol = UDPv6
 		}
 	case *net.UnixAddr:
-		// Unix only needs the dest type to match; it reads no fields off destAddr,
-		// so this stays a blank assertion (binding it would be an unused variable).
-		if _, ok := destAddr.(*net.UnixAddr); !ok {
+		destAddr, ok := destAddr.(*net.UnixAddr)
+		if !ok {
+			break
+		}
+		// Both ends must agree on stream vs datagram: there is no meaningful
+		// connection mixing the two, so a mismatched pair stays UNSPEC rather than
+		// being labeled with the source's flavor alone. Mirrors the both-ends
+		// family selection used for TCP/UDP above.
+		if sourceAddr.Net != destAddr.Net {
 			break
 		}
 		switch sourceAddr.Net {

--- a/header.go
+++ b/header.go
@@ -85,10 +85,16 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 	}
 	switch sourceAddr := sourceAddr.(type) {
 	case *net.TCPAddr:
+		// Both ends must be the same Addr type; bind destAddr to read its IP below.
 		destAddr, ok := destAddr.(*net.TCPAddr)
 		if !ok {
 			break
 		}
+		// Pick the family from BOTH addresses, not just the source: use v4 only
+		// when both are IPv4, otherwise fall back to v6 (the v4 side is then
+		// serialized as a v4-mapped IPv6, ::ffff:x.x.x.x). The previous
+		// source-only check mislabeled a v4-source/v6-dest pair as TCPv4 and then
+		// failed in formatVersion1.
 		switch {
 		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = TCPv4
@@ -100,6 +106,7 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 		if !ok {
 			break
 		}
+		// Same both-ends family selection as TCP above.
 		switch {
 		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
 			h.TransportProtocol = UDPv4
@@ -107,6 +114,8 @@ func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
 			h.TransportProtocol = UDPv6
 		}
 	case *net.UnixAddr:
+		// Unix only needs the dest type to match; it reads no fields off destAddr,
+		// so this stays a blank assertion (binding it would be an unused variable).
 		if _, ok := destAddr.(*net.UnixAddr); !ok {
 			break
 		}

--- a/header_test.go
+++ b/header_test.go
@@ -603,6 +603,33 @@ func TestHeaderProxyFromAddrs(t *testing.T) {
 			},
 		},
 		{
+			// Mixed family (v4 source, genuine v6 dest) must resolve to TCPv6, not
+			// TCPv4. The old source-only logic chose TCPv4 here and then errored in
+			// formatVersion1; see the both-ends family selection in header.go.
+			name: "TCPv4SrcIPv6Dst",
+			sourceAddr: &net.TCPAddr{
+				IP:   net.ParseIP(testSourceIPv4Addr),
+				Port: 1000,
+			},
+			destAddr: &net.TCPAddr{
+				IP:   net.ParseIP("fde7::1"),
+				Port: 2000,
+			},
+			expected: &Header{
+				Version:           2,
+				Command:           PROXY,
+				TransportProtocol: TCPv6,
+				SourceAddr: &net.TCPAddr{
+					IP:   net.ParseIP(testSourceIPv4Addr),
+					Port: 1000,
+				},
+				DestinationAddr: &net.TCPAddr{
+					IP:   net.ParseIP("fde7::1"),
+					Port: 2000,
+				},
+			},
+		},
+		{
 			name: "UDPv4",
 			sourceAddr: &net.UDPAddr{
 				IP:   net.ParseIP(testSourceIPv4Addr),

--- a/header_test.go
+++ b/header_test.go
@@ -810,6 +810,21 @@ func TestHeaderProxyFromAddrs(t *testing.T) {
 			},
 			expected: unspec,
 		},
+		{
+			// Stream source paired with a datagram destination is not a coherent
+			// connection, so the header stays UNSPEC instead of adopting the
+			// source's flavor.
+			name: "UnixNetMismatch",
+			sourceAddr: &net.UnixAddr{
+				Net:  networkUnix,
+				Name: testUnixSrcName,
+			},
+			destAddr: &net.UnixAddr{
+				Net:  networkUnixgram,
+				Name: testUnixDstName,
+			},
+			expected: unspec,
+		},
 	}
 
 	for _, tt := range tests {

--- a/header_test.go
+++ b/header_test.go
@@ -432,7 +432,8 @@ func TestWriteTo(t *testing.T) {
 	}
 
 	if _, err := invalidHeader.WriteTo(&buf); err == nil {
-		t.Fatalf("should have thrown error %q", err.Error())
+		// err is nil in this branch, so don't format it (would nil-deref).
+		t.Fatal("should have thrown error")
 	}
 }
 

--- a/v1.go
+++ b/v1.go
@@ -190,16 +190,26 @@ func (header *Header) formatVersion1() ([]byte, error) {
 		return nil, ErrInvalidAddress
 	}
 
+	// netip.Addr (not net.IP) is used here so String() honors the address family
+	// declared by TransportProtocol. AddrFromSlice reports ok=false when the slice
+	// is nil (e.g. To4() on an IPv6-only address), which the guard below rejects.
 	var sourceIP, destIP netip.Addr
 	switch header.TransportProtocol {
 	case TCPv4:
 		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To4())
 		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To4())
 	case TCPv6:
-		// Use netip.Addr instead net.IP so to guarantee Is6() address, ie a v4-mapped IP in a TCP6 header
-		// serializes as ::ffff:1.2.3.4 instead of net.IP.String()'s collapsed 1.2.3.4.
+		// Use netip.Addr instead of net.IP to guarantee an Is6() address; i.e. a
+		// v4-mapped IP in a TCP6 header serializes as ::ffff:1.2.3.4 instead of
+		// net.IP.String()'s collapsed 1.2.3.4.
 		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To16())
 		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To16())
+	default:
+		// Unreachable today: the proto switch at the top of this function already
+		// returns for anything other than TCPv4/TCPv6. Kept so a future protocol
+		// can't fall through with zero-value IPs while sourceOK/destOK still hold
+		// from the type assertion above.
+		return nil, ErrInvalidAddress
 	}
 	if !sourceOK || !destOK {
 		return nil, ErrInvalidAddress

--- a/v1.go
+++ b/v1.go
@@ -190,16 +190,18 @@ func (header *Header) formatVersion1() ([]byte, error) {
 		return nil, ErrInvalidAddress
 	}
 
-	sourceIP, destIP := sourceAddr.IP, destAddr.IP
+	var sourceIP, destIP netip.Addr
 	switch header.TransportProtocol {
 	case TCPv4:
-		sourceIP = sourceIP.To4()
-		destIP = destIP.To4()
+		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To4())
+		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To4())
 	case TCPv6:
-		sourceIP = sourceIP.To16()
-		destIP = destIP.To16()
+		// Use netip.Addr instead net.IP so to guarantee Is6() address, ie a v4-mapped IP in a TCP6 header
+		// serializes as ::ffff:1.2.3.4 instead of net.IP.String()'s collapsed 1.2.3.4.
+		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To16())
+		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To16())
 	}
-	if sourceIP == nil || destIP == nil {
+	if !sourceOK || !destOK {
 		return nil, ErrInvalidAddress
 	}
 

--- a/v1_test.go
+++ b/v1_test.go
@@ -120,7 +120,12 @@ var validParseAndWriteV1Tests = []struct {
 	desc           string
 	reader         *bufio.Reader
 	expectedHeader *Header
-	skipWrite      bool
+	// expectedWrite is the exact wire output formatVersion1 must produce for
+	// expectedHeader. It is asserted byte-for-byte by TestWriteV1Valid, which a
+	// round-trip + EqualsTo check cannot do: EqualsTo compares net.IP.String(),
+	// so a v4-mapped IPv6 ("::ffff:1.2.3.4") and its collapsed v4 form ("1.2.3.4")
+	// look equal there, hiding serialization regressions.
+	expectedWrite string
 }{
 	{
 		desc:   "TCP4",
@@ -132,6 +137,7 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        v4addr,
 			DestinationAddr:   v4addr,
 		},
+		expectedWrite: "PROXY TCP4 127.0.0.1 127.0.0.1 65533 65533" + crlf,
 	},
 	{
 		desc:   "TCP6",
@@ -143,6 +149,7 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        v6addr,
 			DestinationAddr:   v6addr,
 		},
+		expectedWrite: "PROXY TCP6 ::1 ::1 65533 65533" + crlf,
 	},
 	{
 		desc:   "TCP4IN6",
@@ -154,10 +161,10 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        v4addr,
 			DestinationAddr:   v4addr,
 		},
-		// we skip write test because net.ParseIP converts ::ffff:127.0.0.1 to v4
-		// instead of preserving the v4 in v6 form, so, after serializing the header,
-		// we end up with v6 protocol and a v4 IP which is invalid
-		skipWrite: true,
+		// Regression lock for the netip.Addr fix: a v4 IP carried in a TCP6 header
+		// must serialize as ::ffff:127.0.0.1, not the collapsed 127.0.0.1 that
+		// net.IP.String() used to emit (which produced an invalid v4-in-TCP6 line).
+		expectedWrite: "PROXY TCP6 ::ffff:127.0.0.1 ::ffff:127.0.0.1 65533 65533" + crlf,
 	},
 	{
 		desc:   "unknown",
@@ -169,6 +176,7 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        nil,
 			DestinationAddr:   nil,
 		},
+		expectedWrite: "PROXY UNKNOWN" + crlf,
 	},
 	{
 		desc:   "unknown with addresses and ports",
@@ -180,6 +188,8 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        nil,
 			DestinationAddr:   nil,
 		},
+		// UNSPEC always serializes to the short form; addresses are dropped.
+		expectedWrite: "PROXY UNKNOWN" + crlf,
 	},
 	{
 		desc:   "TCP6 IPv4 src IPv4 dst",
@@ -191,7 +201,8 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("192.0.2.1").To16(), Port: 1234},
 			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("192.0.2.2").To16(), Port: 5678},
 		},
-		skipWrite: true,
+		// Both addresses are v4-mapped, so both must serialize in ::ffff: form.
+		expectedWrite: "PROXY TCP6 ::ffff:192.0.2.1 ::ffff:192.0.2.2 1234 5678" + crlf,
 	},
 	{
 		desc:   "TCP6 IPv6 src IPv4 dst",
@@ -203,7 +214,8 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("2001:db8::1").To16(), Port: 51512},
 			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("192.0.2.1").To16(), Port: 22},
 		},
-		skipWrite: true,
+		// Mixed family: genuine IPv6 source stays as-is, v4 dest becomes v4-mapped.
+		expectedWrite: "PROXY TCP6 2001:db8::1 ::ffff:192.0.2.1 51512 22" + crlf,
 	},
 	{
 		desc:   "TCP6 IPv4 src IPv6 dst",
@@ -215,7 +227,8 @@ var validParseAndWriteV1Tests = []struct {
 			SourceAddr:        &net.TCPAddr{IP: net.ParseIP("192.0.2.1").To16(), Port: 51512},
 			DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("2001:db8::1").To16(), Port: 22},
 		},
-		skipWrite: true,
+		// Mixed family: v4 source becomes v4-mapped, genuine IPv6 dest stays as-is.
+		expectedWrite: "PROXY TCP6 ::ffff:192.0.2.1 2001:db8::1 51512 22" + crlf,
 	},
 }
 
@@ -235,9 +248,6 @@ func TestParseV1Valid(t *testing.T) {
 
 func TestWriteV1Valid(t *testing.T) {
 	for _, tt := range validParseAndWriteV1Tests {
-		if tt.skipWrite {
-			continue
-		}
 		t.Run(tt.desc, func(t *testing.T) {
 			var b bytes.Buffer
 			w := bufio.NewWriter(&b)
@@ -248,7 +258,17 @@ func TestWriteV1Valid(t *testing.T) {
 				t.Fatal("unexpected error ", err)
 			}
 
-			// Read written bytes to validate written header
+			// Assert the exact wire bytes. This is what pins address-family
+			// formatting (e.g. v4-mapped IPv6 rendering as ::ffff:x.x.x.x); the
+			// EqualsTo round-trip below is blind to it because it compares
+			// net.IP.String(), which collapses ::ffff:x.x.x.x back to x.x.x.x.
+			if got := b.String(); got != tt.expectedWrite {
+				t.Fatalf("expected wire %q, actual %q", tt.expectedWrite, got)
+			}
+
+			// Round-trip the written bytes to ensure the parser accepts what the
+			// formatter emits (catches format/parse drift that a byte check alone
+			// would miss).
 			r := bufio.NewReader(&b)
 			newHeader, err := Read(r)
 			if err != nil {


### PR DESCRIPTION
Fixes #169

### v1

- `default: return nil, ErrInvalidAddress` in the format switch

### Tests

- Dropped all four `skipWrite` flags
- Added byte-level wire assertion (the real regression lock)
- Added mixed-family case (`TCPv4SrcIPv6Dst` → `TCPv6`)
